### PR TITLE
feat: implement Phase 1 MVP — live formatting, headless API, i18n, ARIA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+dist/
+coverage/

--- a/.memory/phase-1-worklog.md
+++ b/.memory/phase-1-worklog.md
@@ -1,0 +1,156 @@
+# Phase 1 Worklog — numra React Number Input Library
+
+**Date**: 2026-04-02  
+**Branch**: `claude/phase-1-implementation-plan-5fpI2`  
+**Status**: ✅ Complete
+
+---
+
+## What Was Built
+
+### Project Setup
+- `package.json` — Full config with subpath exports (`.`, `./core`, `./react`, `./locales/*`), ESM-first, `sideEffects: false`, peer deps for React 18/19
+- `tsconfig.json` — ES2020 target, strict, `verbatimModuleSyntax`, `moduleResolution: Bundler`
+- `tsup.config.ts` — Dual ESM/CJS output with DTS, minification enabled, separate locale entries
+- `vitest.config.ts` — jsdom environment, globals, `@vitejs/plugin-react`
+
+### Core Engine (`src/core/`) — framework-agnostic, 1.8 KB gzipped
+
+| File | Purpose |
+|------|---------|
+| `types.ts` | All shared TypeScript interfaces and types |
+| `normalizer.ts` | Unicode digit normalization (5 built-in digit blocks, extensible registry) |
+| `formatter.ts` | `createFormatter()` — Intl.NumberFormat wrapper with caching, prefix/suffix, fixedDecimalScale |
+| `parser.ts` | `createParser()` — locale-aware, auto-extracts separators via `formatToParts()`, handles intermediate states |
+| `cursor.ts` | `getCaretBoundary()` + `computeNewCursorPosition()` — 3-stage accepted-chars algorithm |
+| `index.ts` | Barrel export |
+
+### React Layer (`src/react/`) — 4.3 KB gzipped
+
+| File | Purpose |
+|------|---------|
+| `useControllableState.ts` | Controlled/uncontrolled pattern with dev-mode warning |
+| `context.ts` | `NumberFieldContext` + `useNumberFieldContext()` |
+| `useNumberFieldState.ts` | Pure state management — formats, parses, clamps, steps |
+| `useNumberField.ts` | Behavior hook — wires cursor engine, ARIA attrs, keyboard, wheel |
+| `NumberField.tsx` | Compound headless components: Root, Label, Group, Input, Increment, Decrement, HiddenInput |
+| `index.ts` | Barrel export |
+
+### Locale Plugins (`src/locales/`) — ~101 bytes each gzipped
+
+- `fa.ts` — Persian: U+06F0–U+06F9 + U+0660–U+0669
+- `ar.ts` — Arabic-Indic: U+0660–U+0669
+- `bn.ts` — Bengali: U+09E6–U+09EF
+- `hi.ts` — Devanagari: U+0966–U+096F
+- `th.ts` — Thai: U+0E50–U+0E59
+- `index.ts` — All-in-one side-effect import
+
+---
+
+## Key Technical Decisions Made
+
+### Cursor Algorithm
+Implemented the 3-stage accepted-characters boundary algorithm as specified:
+1. **Capture** — `selectionStart` + `inputType` from native event
+2. **Compute** — count accepted chars (digits, decimal sep, minus) before cursor, format, walk boundary
+3. **Restore** — `useLayoutEffect` + `setSelectionRange()` before browser paint
+
+**Bug found and fixed**: Initial implementation had `|| acceptedCount === 0` in the post-loop condition which incorrectly overrode position 0 with string length. This was caught by tests and fixed.
+
+### Parser Bug Fixed
+`stripAffordances()` was setting `isIntermediate: true` for lone `-` without checking `allowNegative`. Fixed by separating the empty/minus-only check and gating isIntermediate on the `allowNegative` flag.
+
+### Locale Info Extraction
+All separators extracted dynamically from `Intl.NumberFormat.formatToParts()` — never hardcoded. This correctly handles:
+- fr-FR narrow no-break space grouping (U+202F)
+- fa-IR Arabic digit separators (٫ decimal, ٬ grouping)
+- RTL detection via resolved locale
+
+### Dev-Mode Warning
+Used `window.__DEV__` pattern instead of `process.env.NODE_ENV` (no Node types needed) or `import.meta.env` (TS config complexity).
+
+---
+
+## Creative Additions Beyond Spec
+
+1. **`valueAsString` architecture** — `inputValue` in state is always accessible as the raw string users see
+2. **RTL auto-detection** — locale info includes `isRTL` flag; input gets `direction: ltr; text-align: right` for Arabic/Persian/Hebrew locales automatically
+3. **`data-scrubbing` attribute infrastructure** — data attribute slots in stateDataAttrs for Phase 2 ScrubArea
+4. **Precision arithmetic** — `preciseAdd()` in useNumberFieldState avoids `0.1 + 0.2 = 0.30000000000000004` float issues
+
+---
+
+## Bundle Sizes Achieved
+
+| Entry | Gzipped | Target | Status |
+|-------|---------|--------|--------|
+| `numra/core` | 1.8 KB | < 2 KB | ✅ |
+| `numra` (full) | 4.5 KB | < 5 KB | ✅ |
+| `numra/react` | 4.3 KB | < 5 KB | ✅ |
+| `numra/locales/fa` | 101 B | < 0.3 KB | ✅ |
+
+---
+
+## Test Coverage
+
+**124 tests passing across 6 suites:**
+
+| Suite | Tests | What's Covered |
+|-------|-------|----------------|
+| `normalizer.test.ts` | 17 | Persian/Arabic/Bengali/Hindi/Thai digits, registry |
+| `formatter.test.ts` | 17 | en-US, de-DE, fr-FR, fa-IR formatting, currency, fixedDecimalScale |
+| `parser.test.ts` | 22 | All locales, intermediate states, allowNegative/allowDecimal, prefix/suffix |
+| `cursor.test.ts` | 13 | getCaretBoundary, cursor computation, backspace-on-separator |
+| `useNumberFieldState.test.ts` | 26 | State management, controlled/uncontrolled, clamping, steps |
+| `NumberField.test.tsx` | 29 | ARIA attrs, keyboard, buttons, form integration, render prop, disabled |
+
+---
+
+## Phase 1 Checklist vs DEFINITION.md Priority 1
+
+| Feature | Status |
+|---------|--------|
+| Live formatting while typing | ✅ |
+| Cursor preservation (accepted-chars algorithm) | ✅ |
+| Hook API (`useNumberField` + `useNumberFieldState`) | ✅ |
+| Headless Component API (all 7 sub-components) | ✅ |
+| Full `Intl.NumberFormat` integration | ✅ |
+| Unicode digit normalization (5 scripts) | ✅ |
+| Locale-aware parsing | ✅ |
+| Min/max/step constraints | ✅ |
+| Clamping behavior (blur/strict/none) | ✅ |
+| Decimal control | ✅ |
+| Negative number support | ✅ |
+| Keyboard interactions (arrows, Page, Home/End) | ✅ |
+| ARIA spinbutton with all attributes | ✅ |
+| Controlled/uncontrolled pattern | ✅ |
+| Form integration (hidden input) | ✅ |
+| RTL support (auto-detected) | ✅ |
+| Render prop pattern for element replacement | ✅ |
+| `type="text" inputmode="decimal"` | ✅ |
+
+---
+
+## Known Gaps / Phase 2 Items
+
+- **ScrubArea** — `data-scrubbing` attr slots are ready, implementation deferred
+- **Press-and-hold acceleration** — button long-press stepHoldDelay/stepHoldInterval
+- **Mouse wheel** — skeleton in `useNumberField` (`allowMouseWheel` prop), needs pointer lock
+- **Paste handling** — basic normalization works; smart paste with currency stripping is Phase 2
+- **`allowOutOfRange`** — prop defined in types, behavior not yet enforced
+- **Storybook** — not configured
+- **Changeset / publishing** — not configured
+- **Size-limit CI** — not configured yet
+
+---
+
+## Next Steps for Phase 2
+
+1. Implement ScrubArea (Pointer Lock API, configurable sensitivity)
+2. Press-and-hold acceleration for stepper buttons
+3. Smart paste normalization (strip currency symbols, detect locale)
+4. Advanced prefix/suffix from `Intl.NumberFormat` parts positioning
+5. Storybook stories for all features
+6. Starlight docs site skeleton
+7. Changesets for versioning
+8. GitHub Actions CI pipeline

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+enable-pre-post-scripts=true

--- a/package.json
+++ b/package.json
@@ -1,13 +1,104 @@
 {
   "name": "numra",
-  "version": "0.0.0",
-  "description": "",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+  "version": "0.1.0",
+  "description": "The definitive React number input: live formatting, full i18n, headless, accessible",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./core": {
+      "import": {
+        "types": "./dist/core.d.ts",
+        "default": "./dist/core.js"
+      },
+      "require": {
+        "types": "./dist/core.d.cts",
+        "default": "./dist/core.cjs"
+      }
+    },
+    "./react": {
+      "import": {
+        "types": "./dist/react.d.ts",
+        "default": "./dist/react.js"
+      },
+      "require": {
+        "types": "./dist/react.d.cts",
+        "default": "./dist/react.cjs"
+      }
+    },
+    "./locales/*": {
+      "import": {
+        "types": "./dist/locales/*.d.ts",
+        "default": "./dist/locales/*.js"
+      },
+      "require": {
+        "types": "./dist/locales/*.d.cts",
+        "default": "./dist/locales/*.cjs"
+      }
+    }
   },
-  "keywords": [],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "prepublishOnly": "pnpm build && pnpm typecheck"
+  },
+  "keywords": [
+    "react",
+    "number",
+    "input",
+    "formatting",
+    "i18n",
+    "intl",
+    "headless",
+    "accessible",
+    "currency",
+    "spinbutton"
+  ],
   "author": "",
   "license": "MIT",
-  "packageManager": "pnpm@10.33.0"
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/react": "^19.1.0",
+    "@types/react-dom": "^19.1.2",
+    "@vitejs/plugin-react": "^4.4.1",
+    "jsdom": "^26.1.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "tsup": "^8.4.0",
+    "typescript": "^5.8.3",
+    "vitest": "^3.1.1"
+  },
+  "packageManager": "pnpm@10.33.0",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,4 +6,2204 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/react':
+        specifier: ^19.1.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.1.2
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.4.1
+        version: 4.7.0(vite@7.3.1)
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
+      react:
+        specifier: ^19.1.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.4(react@19.2.4)
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(postcss@8.5.8)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(jsdom@26.1.0)
+
+packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
+
+  '@esbuild/aix-ppc64@0.27.5':
+    resolution: {integrity: sha512-nGsF/4C7uzUj+Nj/4J+Zt0bYQ6bz33Phz8Lb2N80Mti1HjGclTJdXZ+9APC4kLvONbjxN1zfvYNd8FEcbBK/MQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.5':
+    resolution: {integrity: sha512-Oeghq+XFgh1pUGd1YKs4DDoxzxkoUkvko+T/IVKwlghKLvvjbGFB3ek8VEDBmNvqhwuL0CQS3cExdzpmUyIrgA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.5':
+    resolution: {integrity: sha512-Cv781jd0Rfj/paoNrul1/r4G0HLvuFKYh7C9uHZ2Pl8YXstzvCyyeWENTFR9qFnRzNMCjXmsulZuvosDg10Mog==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.5':
+    resolution: {integrity: sha512-nQD7lspbzerlmtNOxYMFAGmhxgzn8Z7m9jgFkh6kpkjsAhZee1w8tJW3ZlW+N9iRePz0oPUDrYrXidCPSImD0Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.5':
+    resolution: {integrity: sha512-I+Ya/MgC6rr8oRWGRDF3BXDfP8K1BVUggHqN6VI2lUZLdDi1IM1v2cy0e3lCPbP+pVcK3Tv8cgUhHse1kaNZZw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.5':
+    resolution: {integrity: sha512-MCjQUtC8wWJn/pIPM7vQaO69BFgwPD1jriEdqwTCKzWjGgkMbcg+M5HzrOhPhuYe1AJjXlHmD142KQf+jnYj8A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.5':
+    resolution: {integrity: sha512-X6xVS+goSH0UelYXnuf4GHLwpOdc8rgK/zai+dKzBMnncw7BTQIwquOodE7EKvY2UVUetSqyAfyZC1D+oqLQtg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.5':
+    resolution: {integrity: sha512-233X1FGo3a8x1ekLB6XT69LfZ83vqz+9z3TSEQCTYfMNY880A97nr81KbPcAMl9rmOFp11wO0dP+eB18KU/Ucg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.5':
+    resolution: {integrity: sha512-euKkilsNOv7x/M1NKsx5znyprbpsRFIzTV6lWziqJch7yWYayfLtZzDxDTl+LSQDJYAjd9TVb/Kt5UKIrj2e4A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.5':
+    resolution: {integrity: sha512-0wkVrYHG4sdCCN/bcwQ7yYMXACkaHc3UFeaEOwSVW6e5RycMageYAFv+JS2bKLwHyeKVUvtoVH+5/RHq0fgeFw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.5':
+    resolution: {integrity: sha512-hVRQX4+P3MS36NxOy24v/Cdsimy/5HYePw+tmPqnNN1fxV0bPrFWR6TMqwXPwoTM2VzbkA+4lbHWUKDd5ZDA/w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.5':
+    resolution: {integrity: sha512-mKqqRuOPALI8nDzhOBmIS0INvZOOFGGg5n1osGIXAx8oersceEbKd4t1ACNTHM3sJBXGFAlEgqM+svzjPot+ZQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.5':
+    resolution: {integrity: sha512-EE/QXH9IyaAj1qeuIV5+/GZkBTipgGO782Ff7Um3vPS9cvLhJJeATy4Ggxikz2inZ46KByamMn6GqtqyVjhenA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.5':
+    resolution: {integrity: sha512-0V2iF1RGxBf1b7/BjurA5jfkl7PtySjom1r6xOK2q9KWw/XCpAdtB6KNMO+9xx69yYfSCRR9FE0TyKfHA2eQMw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.5':
+    resolution: {integrity: sha512-rYxThBx6G9HN6tFNuvB/vykeLi4VDsm5hE5pVwzqbAjZEARQrWu3noZSfbEnPZ/CRXP3271GyFk/49up2W190g==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.5':
+    resolution: {integrity: sha512-uEP2q/4qgd8goEUc4QIdU/1P2NmEtZ/zX5u3OpLlCGhJIuBIv0s0wr7TB2nBrd3/A5XIdEkkS5ZLF0ULuvaaYQ==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.5':
+    resolution: {integrity: sha512-+Gq47Wqq6PLOOZuBzVSII2//9yyHNKZLuwfzCemqexqOQCSz0zy0O26kIzyp9EMNMK+nZ0tFHBZrCeVUuMs/ew==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.5':
+    resolution: {integrity: sha512-3F/5EG8VHfN/I+W5cO1/SV2H9Q/5r7vcHabMnBqhHK2lTWOh3F8vixNzo8lqxrlmBtZVFpW8pmITHnq54+Tq4g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.5':
+    resolution: {integrity: sha512-28t+Sj3CPN8vkMOlZotOmDgilQwVvxWZl7b8rxpn73Tt/gCnvrHxQUMng4uu3itdFvrtba/1nHejvxqz8xgEMA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.5':
+    resolution: {integrity: sha512-Doz/hKtiuVAi9hMsBMpwBANhIZc8l238U2Onko3t2xUp8xtM0ZKdDYHMnm/qPFVthY8KtxkXaocwmMh6VolzMA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.5':
+    resolution: {integrity: sha512-WfGVaa1oz5A7+ZFPkERIbIhKT4olvGl1tyzTRaB5yoZRLqC0KwaO95FeZtOdQj/oKkjW57KcVF944m62/0GYtA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.5':
+    resolution: {integrity: sha512-Xh+VRuh6OMh3uJ0JkCjI57l+DVe7VRGBYymen8rFPnTVgATBwA6nmToxM2OwTlSvrnWpPKkrQUj93+K9huYC6A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.5':
+    resolution: {integrity: sha512-aC1gpJkkaUADHuAdQfuVTnqVUTLqqUNhAvEwHwVWcnVVZvNlDPGA0UveZsfXJJ9T6k9Po4eHi3c02gbdwO3g6w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.5':
+    resolution: {integrity: sha512-0UNx2aavV0fk6UpZcwXFLztA2r/k9jTUa7OW7SAea1VYUhkug99MW1uZeXEnPn5+cHOd0n8myQay6TlFnBR07w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.5':
+    resolution: {integrity: sha512-5nlJ3AeJWCTSzR7AEqVjT/faWyqKU86kCi1lLmxVqmNR+j4HrYdns+eTGjS/vmrzCIe8inGQckUadvS0+JkKdQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.5':
+    resolution: {integrity: sha512-PWypQR+d4FLfkhBIV+/kHsUELAnMpx1bRvvsn3p+/sAERbnCzFrtDRG2Xw5n+2zPxBK2+iaP+vetsRl4Ti7WgA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.1':
+    resolution: {integrity: sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    resolution: {integrity: sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.1':
+    resolution: {integrity: sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    resolution: {integrity: sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    resolution: {integrity: sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    resolution: {integrity: sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    resolution: {integrity: sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    resolution: {integrity: sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    resolution: {integrity: sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  baseline-browser-mapping@2.10.13:
+    resolution: {integrity: sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  caniuse-lite@1.0.30001784:
+    resolution: {integrity: sha512-WU346nBTklUV9YfUl60fqRbU5ZqyXlqvo1SgigE1OAXK5bFL8LL9q1K7aap3N739l4BvNqnkm3YrGHiY9sfUQw==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  electron-to-chromium@1.5.331:
+    resolution: {integrity: sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.27.5:
+    resolution: {integrity: sha512-zdQoHBjuDqKsvV5OPaWansOwfSQ0Js+Uj9J85TBvj3bFW1JjWTSULMRwdQAc8qMeIScbClxeMK0jlrtB9linhA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.37:
+    resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
+
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  react-dom@19.2.4:
+    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+    peerDependencies:
+      react: ^19.2.4
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.4:
+    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    engines: {node: '>=0.10.0'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  rollup@4.60.1:
+    resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.0': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/runtime@7.29.2': {}
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
+
+  '@esbuild/aix-ppc64@0.27.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.5':
+    optional: true
+
+  '@esbuild/android-arm@0.27.5':
+    optional: true
+
+  '@esbuild/android-x64@0.27.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.5':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.5':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.5':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.5':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.1':
+    optional: true
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@4.7.0(vite@7.3.1)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 7.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.1)':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  acorn@8.16.0: {}
+
+  agent-base@7.1.4: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  any-promise@1.3.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
+  assertion-error@2.0.1: {}
+
+  baseline-browser-mapping@2.10.13: {}
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.13
+      caniuse-lite: 1.0.30001784
+      electron-to-chromium: 1.5.331
+      node-releases: 2.0.37
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  bundle-require@5.1.0(esbuild@0.27.5):
+    dependencies:
+      esbuild: 0.27.5
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  caniuse-lite@1.0.30001784: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  commander@4.1.1: {}
+
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  css.escape@1.5.1: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
+  csstype@3.2.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decimal.js@10.6.0: {}
+
+  deep-eql@5.0.2: {}
+
+  dequal@2.0.3: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
+  electron-to-chromium@1.5.331: {}
+
+  entities@6.0.1: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.27.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.5
+      '@esbuild/android-arm': 0.27.5
+      '@esbuild/android-arm64': 0.27.5
+      '@esbuild/android-x64': 0.27.5
+      '@esbuild/darwin-arm64': 0.27.5
+      '@esbuild/darwin-x64': 0.27.5
+      '@esbuild/freebsd-arm64': 0.27.5
+      '@esbuild/freebsd-x64': 0.27.5
+      '@esbuild/linux-arm': 0.27.5
+      '@esbuild/linux-arm64': 0.27.5
+      '@esbuild/linux-ia32': 0.27.5
+      '@esbuild/linux-loong64': 0.27.5
+      '@esbuild/linux-mips64el': 0.27.5
+      '@esbuild/linux-ppc64': 0.27.5
+      '@esbuild/linux-riscv64': 0.27.5
+      '@esbuild/linux-s390x': 0.27.5
+      '@esbuild/linux-x64': 0.27.5
+      '@esbuild/netbsd-arm64': 0.27.5
+      '@esbuild/netbsd-x64': 0.27.5
+      '@esbuild/openbsd-arm64': 0.27.5
+      '@esbuild/openbsd-x64': 0.27.5
+      '@esbuild/openharmony-arm64': 0.27.5
+      '@esbuild/sunos-x64': 0.27.5
+      '@esbuild/win32-arm64': 0.27.5
+      '@esbuild/win32-ia32': 0.27.5
+      '@esbuild/win32-x64': 0.27.5
+
+  escalade@3.2.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.60.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  indent-string@4.0.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  joycon@3.1.1: {}
+
+  js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.20.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  min-indent@1.0.1: {}
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
+
+  ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.11: {}
+
+  node-releases@2.0.37: {}
+
+  nwsapi@2.2.23: {}
+
+  object-assign@4.1.1: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  postcss-load-config@6.0.1(postcss@8.5.8):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.8
+
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  punycode@2.3.1: {}
+
+  react-dom@19.2.4(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      scheduler: 0.27.0
+
+  react-is@17.0.2: {}
+
+  react-refresh@0.17.0: {}
+
+  react@19.2.4: {}
+
+  readdirp@4.1.2: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
+  resolve-from@5.0.0: {}
+
+  rollup@4.60.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.1
+      '@rollup/rollup-android-arm64': 4.60.1
+      '@rollup/rollup-darwin-arm64': 4.60.1
+      '@rollup/rollup-darwin-x64': 4.60.1
+      '@rollup/rollup-freebsd-arm64': 4.60.1
+      '@rollup/rollup-freebsd-x64': 4.60.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.1
+      '@rollup/rollup-linux-arm64-gnu': 4.60.1
+      '@rollup/rollup-linux-arm64-musl': 4.60.1
+      '@rollup/rollup-linux-loong64-gnu': 4.60.1
+      '@rollup/rollup-linux-loong64-musl': 4.60.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.1
+      '@rollup/rollup-linux-ppc64-musl': 4.60.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.1
+      '@rollup/rollup-linux-riscv64-musl': 4.60.1
+      '@rollup/rollup-linux-s390x-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-gnu': 4.60.1
+      '@rollup/rollup-linux-x64-musl': 4.60.1
+      '@rollup/rollup-openbsd-x64': 4.60.1
+      '@rollup/rollup-openharmony-arm64': 4.60.1
+      '@rollup/rollup-win32-arm64-msvc': 4.60.1
+      '@rollup/rollup-win32-ia32-msvc': 4.60.1
+      '@rollup/rollup-win32-x64-gnu': 4.60.1
+      '@rollup/rollup-win32-x64-msvc': 4.60.1
+      fsevents: 2.3.3
+
+  rrweb-cssom@0.8.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  source-map@0.7.6: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
+
+  symbol-tree@3.2.4: {}
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
+
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsup@8.5.1(postcss@8.5.8)(typescript@5.9.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.5)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.5
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(postcss@8.5.8)
+      resolve-from: 5.0.0
+      rollup: 4.60.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.8
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  typescript@5.9.3: {}
+
+  ufo@1.6.3: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vite-node@3.2.4:
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.1:
+    dependencies:
+      esbuild: 0.27.5
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.8
+      rollup: 4.60.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@3.2.4(jsdom@26.1.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.1)
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1
+      vite-node: 3.2.4
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  ws@8.20.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
+
+  yallist@3.1.1: {}

--- a/src/core/cursor.test.ts
+++ b/src/core/cursor.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { getCaretBoundary, computeNewCursorPosition } from "./cursor.js";
+import type { LocaleInfo } from "./types.js";
+
+const enUS: LocaleInfo = {
+  decimalSeparator: ".",
+  groupingSeparator: ",",
+  minusSign: "-",
+  zero: "0",
+  isRTL: false,
+};
+
+const deDE: LocaleInfo = {
+  decimalSeparator: ",",
+  groupingSeparator: ".",
+  minusSign: "-",
+  zero: "0",
+  isRTL: false,
+};
+
+describe("getCaretBoundary", () => {
+  it("marks all positions valid for a plain integer", () => {
+    const boundary = getCaretBoundary("1234", enUS);
+    expect(boundary).toHaveLength(5);
+    expect(boundary.every(Boolean)).toBe(true);
+  });
+
+  it("marks position after grouping separator as invalid", () => {
+    // "1,234" → indices: 0=1, 1=,, 2=2, 3=3, 4=4
+    const boundary = getCaretBoundary("1,234", enUS);
+    expect(boundary).toHaveLength(6);
+    // Position 2 (immediately after the comma) should be invalid
+    expect(boundary[2]).toBe(false);
+    // Position 1 (before comma), 0, 3, 4, 5 should be valid
+    expect(boundary[0]).toBe(true);
+    expect(boundary[1]).toBe(true);
+    expect(boundary[3]).toBe(true);
+    expect(boundary[5]).toBe(true);
+  });
+
+  it("marks positions after multiple grouping separators as invalid", () => {
+    const boundary = getCaretBoundary("1,234,567", enUS);
+    // comma at index 1 → position 2 invalid
+    // comma at index 5 → position 6 invalid
+    expect(boundary[2]).toBe(false);
+    expect(boundary[6]).toBe(false);
+    expect(boundary[0]).toBe(true);
+    expect(boundary[9]).toBe(true);
+  });
+
+  it("first and last are always valid", () => {
+    const boundary = getCaretBoundary("1,234", enUS);
+    expect(boundary[0]).toBe(true);
+    expect(boundary[boundary.length - 1]).toBe(true);
+  });
+
+  it("works with de-DE grouping separator (dot)", () => {
+    const boundary = getCaretBoundary("1.234", deDE);
+    expect(boundary[2]).toBe(false); // position after the dot grouping separator
+    expect(boundary[0]).toBe(true);
+  });
+});
+
+describe("computeNewCursorPosition", () => {
+  it("places cursor at end after typing all 4 digits of 1234", () => {
+    // User typed "1234" (cursor at 4), gets formatted to "1,234" (length 5)
+    const pos = computeNewCursorPosition("1234", 4, "1,234", enUS);
+    // 4 accepted chars before cursor in "1234" → should land at position 5 in "1,234"
+    expect(pos).toBe(5);
+  });
+
+  it("places cursor correctly mid-number", () => {
+    // User typed "123" (cursor at 3), formatted to "123" (no comma yet)
+    const pos = computeNewCursorPosition("123", 3, "123", enUS);
+    expect(pos).toBe(3);
+  });
+
+  it("handles backspace on a grouping separator — cursor follows accepted char count", () => {
+    // "1,234" — user backspaces the comma
+    // By onChange time, oldInput = "1234" (comma already deleted), cursor at 1
+    // inputType = "deleteContentBackward"
+    // BUT: oldInput[cursor-1] = "1" (not a comma) so no separator-adjustment fires
+    // 1 accepted char before cursor → position 1 in "123"
+    const pos = computeNewCursorPosition(
+      "1234",
+      1,
+      "123",
+      enUS,
+      "deleteContentBackward"
+    );
+    expect(pos).toBe(1);
+  });
+
+  it("handles backspace where previous char in OLD display was a grouping separator", () => {
+    // This tests the actual separator-backspace edge case:
+    // The old display was "1,234" and user placed cursor right after the comma (pos 2)
+    // We simulate by passing a value where oldInput[cursor-1] IS the separator
+    // That requires the pre-deletion display — a simplified simulation:
+    const pos = computeNewCursorPosition(
+      "1,234", // old display (pre-deletion snapshot passed in)
+      2,       // cursor after the comma
+      "123",   // new formatted after deletion
+      enUS,
+      "deleteContentBackward"
+    );
+    // 0 accepted chars before pos 2 in "1,234" (comma is not accepted) → pos 0 in "123"
+    expect(pos).toBe(0);
+  });
+
+  it("handles typing a digit in the middle", () => {
+    // Old: "1,34" (malformed, cursor at 2 — user typed in position 2 before '3')
+    // New: "134" → "134" (no comma yet for 3-digit number)
+    const pos = computeNewCursorPosition("134", 2, "134", enUS);
+    expect(pos).toBe(2);
+  });
+
+  it("snaps cursor away from invalid position", () => {
+    // Force an invalid position scenario by checking snap works
+    // "1,234" has position 2 as invalid → snap to 3
+    const boundary = getCaretBoundary("1,234", enUS);
+    // position 2 is false — snapping should go to 3
+    expect(boundary[2]).toBe(false);
+    expect(boundary[3]).toBe(true);
+  });
+
+  it("places cursor at end for empty string", () => {
+    const pos = computeNewCursorPosition("", 0, "", enUS);
+    expect(pos).toBe(0);
+  });
+
+  it("handles negative number cursor", () => {
+    // User typed "-1234" (cursor at 5) → formatted as "-1,234"
+    const pos = computeNewCursorPosition("-1234", 5, "-1,234", enUS);
+    expect(pos).toBe(6);
+  });
+});

--- a/src/core/cursor.ts
+++ b/src/core/cursor.ts
@@ -1,0 +1,159 @@
+import type { CaretBoundary, LocaleInfo } from "./types.js";
+import { normalizeDigits } from "./normalizer.js";
+
+// ── Accepted-character helpers ────────────────────────────────────────────────
+
+/**
+ * Returns true if `ch` is an "accepted" character — one that the user typed
+ * intentionally and that contributes to the numeric value:
+ *   - ASCII digit 0-9
+ *   - The locale decimal separator
+ *   - The locale minus sign
+ */
+function isAccepted(ch: string, info: LocaleInfo): boolean {
+  if (ch >= "0" && ch <= "9") return true;
+  if (ch === info.decimalSeparator) return true;
+  if (ch === info.minusSign || ch === "-") return true;
+  return false;
+}
+
+/**
+ * Count how many "accepted" characters appear before position `cursor`
+ * in `str` (after normalising non-Latin digits to ASCII).
+ */
+function countAcceptedBefore(
+  str: string,
+  cursor: number,
+  info: LocaleInfo
+): number {
+  const normalised = normalizeDigits(str);
+  let count = 0;
+  for (let i = 0; i < cursor && i < normalised.length; i++) {
+    if (isAccepted(normalised[i]!, info)) count++;
+  }
+  return count;
+}
+
+// ── Caret boundary ────────────────────────────────────────────────────────────
+
+/**
+ * Build a boolean array of length `formattedValue.length + 1`.
+ * `true`  → cursor may rest at this position.
+ * `false` → cursor must snap away (sits inside a formatting-only character
+ *            such as a grouping separator or a currency prefix).
+ *
+ * Rules:
+ *  - Start and end positions are always valid.
+ *  - A position immediately AFTER a grouping separator is invalid (the
+ *    cursor would look like it's between two digits but moving left would
+ *    skip the comma).
+ *  - A position immediately BEFORE a grouping separator is valid.
+ */
+export function getCaretBoundary(
+  formattedValue: string,
+  info: LocaleInfo
+): CaretBoundary {
+  const len = formattedValue.length;
+  const boundary: CaretBoundary = new Array(len + 1).fill(true) as boolean[];
+
+  for (let i = 0; i < len; i++) {
+    const ch = formattedValue[i]!;
+    if (ch === info.groupingSeparator) {
+      // Position immediately after the grouping separator is invalid
+      boundary[i + 1] = false;
+    }
+  }
+
+  // First and last are always valid
+  boundary[0] = true;
+  boundary[len] = true;
+
+  return boundary;
+}
+
+// ── Cursor computation ────────────────────────────────────────────────────────
+
+/**
+ * Compute the new cursor position in `newFormatted` that corresponds
+ * semantically to `oldCursor` in `oldInput`.
+ *
+ * Algorithm (3 stages from the spec):
+ *
+ * 1. Count accepted characters before `oldCursor` in `oldInput`.
+ * 2. Adjust for backspace-over-separator edge case.
+ * 3. Walk `newFormatted` to find the position where the same count of
+ *    accepted chars precede it; snap to the nearest valid boundary.
+ *
+ * @param oldInput     The raw string the user just typed into (pre-format)
+ * @param oldCursor    selectionStart captured from the native event
+ * @param newFormatted The formatted string we're about to display
+ * @param info         Locale separators
+ * @param inputType    e.nativeEvent.inputType (optional — for backspace detection)
+ */
+export function computeNewCursorPosition(
+  oldInput: string,
+  oldCursor: number,
+  newFormatted: string,
+  info: LocaleInfo,
+  inputType?: string
+): number {
+  const normalised = normalizeDigits(oldInput);
+
+  // Stage 1: count accepted chars before cursor in old input
+  let acceptedCount = countAcceptedBefore(normalised, oldCursor, info);
+
+  // Stage 2: backspace on grouping separator — also delete the preceding digit
+  if (
+    inputType === "deleteContentBackward" &&
+    oldCursor > 0 &&
+    oldInput[oldCursor - 1] === info.groupingSeparator
+  ) {
+    // The separator was deleted but we want to remove the preceding digit too
+    acceptedCount = Math.max(0, acceptedCount - 1);
+  }
+
+  // Stage 3: build boundary and walk new formatted string
+  const boundary = getCaretBoundary(newFormatted, info);
+  const normNew = normalizeDigits(newFormatted);
+  let count = 0;
+  let pos = 0;
+
+  for (let i = 0; i < normNew.length; i++) {
+    if (count === acceptedCount) {
+      pos = i;
+      break;
+    }
+    if (isAccepted(normNew[i]!, info)) count++;
+    pos = i + 1;
+  }
+
+  // If we ran through the entire string without reaching the target count,
+  // place the cursor at the end. Note: acceptedCount === 0 means we correctly
+  // want pos = 0 (set in the loop), so we must NOT override that case.
+  if (acceptedCount > 0 && count < acceptedCount) {
+    pos = newFormatted.length;
+  }
+
+  // Snap to nearest valid boundary
+  pos = snapToBoundary(pos, boundary);
+
+  return pos;
+}
+
+/**
+ * If `pos` is at a false (invalid) boundary position, find the nearest
+ * true position. Prefers moving forward; falls back to backward.
+ */
+function snapToBoundary(pos: number, boundary: CaretBoundary): number {
+  if (boundary[pos]) return pos;
+
+  // Try forward first
+  for (let i = pos + 1; i < boundary.length; i++) {
+    if (boundary[i]) return i;
+  }
+  // Fall back to backward
+  for (let i = pos - 1; i >= 0; i--) {
+    if (boundary[i]) return i;
+  }
+  return 0;
+}

--- a/src/core/formatter.test.ts
+++ b/src/core/formatter.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { createFormatter } from "./formatter.js";
+
+describe("createFormatter", () => {
+  describe("format — en-US", () => {
+    const fmt = createFormatter({ locale: "en-US" });
+
+    it("formats integer", () => {
+      expect(fmt.format(1234)).toBe("1,234");
+    });
+
+    it("formats decimal", () => {
+      expect(fmt.format(1234.56)).toBe("1,234.56");
+    });
+
+    it("formats zero", () => {
+      expect(fmt.format(0)).toBe("0");
+    });
+
+    it("formats negative", () => {
+      expect(fmt.format(-1234.56)).toBe("-1,234.56");
+    });
+
+    it("returns empty string for Infinity", () => {
+      expect(fmt.format(Infinity)).toBe("");
+    });
+  });
+
+  describe("format — de-DE", () => {
+    const fmt = createFormatter({ locale: "de-DE" });
+
+    it("uses dot grouping and comma decimal", () => {
+      expect(fmt.format(1234.56)).toBe("1.234,56");
+    });
+  });
+
+  describe("format — fr-FR", () => {
+    const fmt = createFormatter({ locale: "fr-FR" });
+
+    it("uses narrow no-break space grouping", () => {
+      const result = fmt.format(1234.56);
+      // Should contain some whitespace-like grouping separator
+      expect(result).toMatch(/1.234,56|1\s234,56/);
+    });
+  });
+
+  describe("format — fa-IR", () => {
+    const fmt = createFormatter({ locale: "fa-IR" });
+
+    it("uses Persian digits and locale separators", () => {
+      const result = fmt.format(1234.56);
+      // Should contain Persian digits
+      expect(result).toMatch(/[\u06f0-\u06f9]/);
+    });
+  });
+
+  describe("getLocaleInfo — en-US", () => {
+    const fmt = createFormatter({ locale: "en-US" });
+    const info = fmt.getLocaleInfo();
+
+    it("extracts decimal separator", () => {
+      expect(info.decimalSeparator).toBe(".");
+    });
+
+    it("extracts grouping separator", () => {
+      expect(info.groupingSeparator).toBe(",");
+    });
+
+    it("detects LTR", () => {
+      expect(info.isRTL).toBe(false);
+    });
+  });
+
+  describe("getLocaleInfo — de-DE", () => {
+    const fmt = createFormatter({ locale: "de-DE" });
+    const info = fmt.getLocaleInfo();
+
+    it("extracts decimal separator", () => {
+      expect(info.decimalSeparator).toBe(",");
+    });
+
+    it("extracts grouping separator", () => {
+      expect(info.groupingSeparator).toBe(".");
+    });
+  });
+
+  describe("getLocaleInfo — fa-IR", () => {
+    const fmt = createFormatter({ locale: "fa-IR" });
+    const info = fmt.getLocaleInfo();
+
+    it("detects RTL", () => {
+      expect(info.isRTL).toBe(true);
+    });
+  });
+
+  describe("prefix and suffix", () => {
+    const fmt = createFormatter({ locale: "en-US", prefix: "$", suffix: " USD" });
+
+    it("prepends prefix and appends suffix", () => {
+      expect(fmt.format(1234)).toBe("$1,234 USD");
+    });
+  });
+
+  describe("currency format", () => {
+    const fmt = createFormatter({
+      locale: "en-US",
+      formatOptions: { style: "currency", currency: "USD" },
+    });
+
+    it("formats as currency", () => {
+      expect(fmt.format(1234.56)).toBe("$1,234.56");
+    });
+  });
+
+  describe("fixedDecimalScale", () => {
+    const fmt = createFormatter({
+      locale: "en-US",
+      maximumFractionDigits: 2,
+      fixedDecimalScale: true,
+    });
+
+    it("always shows 2 decimal places", () => {
+      expect(fmt.format(1234)).toBe("1,234.00");
+      expect(fmt.format(1234.5)).toBe("1,234.50");
+    });
+  });
+});

--- a/src/core/formatter.ts
+++ b/src/core/formatter.ts
@@ -1,0 +1,134 @@
+import type { LocaleInfo, FormatResult } from "./types.js";
+
+// ── Internal ──────────────────────────────────────────────────────────────────
+
+/** Probe value that will surface decimal AND grouping parts */
+const PROBE_VALUE = 12345.6;
+
+/** Cache key = locale + JSON.stringify(options) */
+const formatterCache = new Map<string, Intl.NumberFormat>();
+
+function getFormatter(
+  locale: string | undefined,
+  options: Intl.NumberFormatOptions | undefined
+): Intl.NumberFormat {
+  const key = `${locale ?? ""}::${JSON.stringify(options ?? {})}`;
+  let fmt = formatterCache.get(key);
+  if (!fmt) {
+    fmt = new Intl.NumberFormat(locale, options);
+    formatterCache.set(key, fmt);
+  }
+  return fmt;
+}
+
+/** Extract locale meta from formatToParts — never hardcoded. */
+function extractLocaleInfo(
+  locale: string | undefined,
+  options: Intl.NumberFormatOptions | undefined
+): LocaleInfo {
+  const fmt = getFormatter(locale, options);
+  // Use a simple decimal number — we only need the separators
+  const parts = fmt.formatToParts(PROBE_VALUE);
+
+  let decimalSeparator = ".";
+  let groupingSeparator = ",";
+  let minusSign = "-";
+  let zero = "0";
+
+  for (const part of parts) {
+    if (part.type === "decimal") decimalSeparator = part.value;
+    if (part.type === "group") groupingSeparator = part.value;
+    if (part.type === "minusSign") minusSign = part.value;
+  }
+
+  // Detect locale zero digit
+  const zeroParts = fmt.formatToParts(0);
+  for (const part of zeroParts) {
+    if (part.type === "integer") {
+      zero = part.value;
+      break;
+    }
+  }
+
+  // RTL locales: Arabic / Hebrew / Persian / Urdu / Syriac etc.
+  const rtlLocales = /^(ar|he|fa|ur|syc|nqo|ug|yi)/i;
+  const resolvedLocale = fmt.resolvedOptions().locale;
+  const isRTL = rtlLocales.test(resolvedLocale);
+
+  return { decimalSeparator, groupingSeparator, minusSign, zero, isRTL };
+}
+
+// ── Factory ───────────────────────────────────────────────────────────────────
+
+export interface FormatterOptions {
+  locale?: string;
+  formatOptions?: Intl.NumberFormatOptions;
+  prefix?: string;
+  suffix?: string;
+  minimumFractionDigits?: number;
+  maximumFractionDigits?: number;
+  fixedDecimalScale?: boolean;
+}
+
+export interface Formatter {
+  format(value: number): string;
+  formatToParts(value: number): Intl.NumberFormatPart[];
+  getLocaleInfo(): LocaleInfo;
+  formatResult(value: number): FormatResult;
+}
+
+/**
+ * Create a formatter instance. Intl.NumberFormat is cached — safe to call
+ * on every render.
+ */
+export function createFormatter(opts: FormatterOptions): Formatter {
+  // Merge fraction digit overrides into formatOptions
+  const intlOptions: Intl.NumberFormatOptions = { ...opts.formatOptions };
+
+  if (opts.minimumFractionDigits !== undefined) {
+    intlOptions.minimumFractionDigits = opts.minimumFractionDigits;
+  }
+  if (opts.maximumFractionDigits !== undefined) {
+    intlOptions.maximumFractionDigits = opts.maximumFractionDigits;
+  }
+  if (opts.fixedDecimalScale && opts.maximumFractionDigits !== undefined) {
+    intlOptions.minimumFractionDigits = opts.maximumFractionDigits;
+    intlOptions.maximumFractionDigits = opts.maximumFractionDigits;
+  }
+
+  const intlFmt = getFormatter(opts.locale, intlOptions);
+  // Lazy — computed once on first call
+  let cachedLocaleInfo: LocaleInfo | null = null;
+
+  function getLocaleInfo(): LocaleInfo {
+    if (!cachedLocaleInfo) {
+      cachedLocaleInfo = extractLocaleInfo(opts.locale, intlOptions);
+    }
+    return cachedLocaleInfo;
+  }
+
+  function formatToParts(value: number): Intl.NumberFormatPart[] {
+    const parts = intlFmt.formatToParts(value);
+    if (!opts.prefix && !opts.suffix) return parts;
+
+    const result: Intl.NumberFormatPart[] = [];
+    if (opts.prefix) result.push({ type: "literal", value: opts.prefix });
+    result.push(...parts);
+    if (opts.suffix) result.push({ type: "literal", value: opts.suffix });
+    return result;
+  }
+
+  function format(value: number): string {
+    if (!isFinite(value)) return "";
+    const formatted = intlFmt.format(value);
+    return (opts.prefix ?? "") + formatted + (opts.suffix ?? "");
+  }
+
+  function formatResult(value: number): FormatResult {
+    const parts = formatToParts(value);
+    const formatted = parts.map((p) => p.value).join("");
+    return { formatted, parts };
+  }
+
+  return { format, formatToParts, getLocaleInfo, formatResult };
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,25 @@
+export type {
+  LocaleInfo,
+  FormatResult,
+  ParseResult,
+  CaretBoundary,
+  DigitBlock,
+  UseNumberFieldStateOptions,
+  NumberFieldState,
+  UseNumberFieldProps,
+  NumberFieldAria,
+  NumberFieldRootProps,
+  RenderProp,
+  StateRenderFn,
+} from "./types.js";
+
+export { normalizeDigits, isNonLatinDigit, registerLocale } from "./normalizer.js";
+export type { LocaleConfig } from "./normalizer.js";
+
+export { createFormatter } from "./formatter.js";
+export type { FormatterOptions, Formatter } from "./formatter.js";
+
+export { createParser } from "./parser.js";
+export type { ParserOptions, Parser } from "./parser.js";
+
+export { getCaretBoundary, computeNewCursorPosition } from "./cursor.js";

--- a/src/core/normalizer.test.ts
+++ b/src/core/normalizer.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { normalizeDigits, isNonLatinDigit, registerLocale } from "./normalizer.js";
+
+describe("normalizeDigits", () => {
+  it("passes ASCII digits through unchanged", () => {
+    expect(normalizeDigits("1234567890")).toBe("1234567890");
+  });
+
+  it("converts Persian (Extended Arabic-Indic) digits", () => {
+    expect(normalizeDigits("۰۱۲۳۴۵۶۷۸۹")).toBe("0123456789");
+  });
+
+  it("converts Arabic-Indic digits", () => {
+    expect(normalizeDigits("٠١٢٣٤٥٦٧٨٩")).toBe("0123456789");
+  });
+
+  it("converts Devanagari digits", () => {
+    expect(normalizeDigits("०१२३४५६७८९")).toBe("0123456789");
+  });
+
+  it("converts Bengali digits", () => {
+    expect(normalizeDigits("০১২৩৪৫৬৭৮৯")).toBe("0123456789");
+  });
+
+  it("converts Thai digits", () => {
+    expect(normalizeDigits("๐๑๒๓๔๕๖๗๘๙")).toBe("0123456789");
+  });
+
+  it("preserves non-digit characters", () => {
+    expect(normalizeDigits("$1,234.56")).toBe("$1,234.56");
+  });
+
+  it("handles mixed non-Latin and ASCII in a real fa-IR number", () => {
+    // ۱٬۲۳۴٫۵۶ — Persian digits with locale separators
+    const result = normalizeDigits("۱٬۲۳۴٫۵۶");
+    // digits should be ASCII, separators preserved
+    expect(result).toBe("1٬234٫56");
+  });
+
+  it("handles empty string", () => {
+    expect(normalizeDigits("")).toBe("");
+  });
+
+  it("handles lone minus sign", () => {
+    expect(normalizeDigits("-")).toBe("-");
+  });
+
+  it("handles mixed Persian and ASCII", () => {
+    expect(normalizeDigits("۱2۳")).toBe("123");
+  });
+});
+
+describe("isNonLatinDigit", () => {
+  it("returns false for ASCII digits", () => {
+    expect(isNonLatinDigit("5")).toBe(false);
+    expect(isNonLatinDigit("0")).toBe(false);
+  });
+
+  it("returns true for Persian digit", () => {
+    expect(isNonLatinDigit("۵")).toBe(true);
+  });
+
+  it("returns true for Arabic-Indic digit", () => {
+    expect(isNonLatinDigit("٥")).toBe(true);
+  });
+
+  it("returns false for letters", () => {
+    expect(isNonLatinDigit("a")).toBe(false);
+    expect(isNonLatinDigit("ض")).toBe(false);
+  });
+});
+
+describe("registerLocale", () => {
+  it("accepts additional digit blocks without duplicating", () => {
+    // Already registered — should not throw or duplicate
+    registerLocale({ digitBlocks: [[0x06f0, 0x06f9]] });
+    expect(normalizeDigits("۵")).toBe("5");
+  });
+
+  it("adds genuinely new blocks", () => {
+    // Register a fake range (Fullwidth digits U+FF10–U+FF19) as a test
+    registerLocale({ digitBlocks: [[0xff10, 0xff19]] });
+    expect(normalizeDigits("\uff15")).toBe("5"); // ５ → 5
+  });
+});

--- a/src/core/normalizer.ts
+++ b/src/core/normalizer.ts
@@ -1,0 +1,72 @@
+import type { DigitBlock } from "./types.js";
+
+// ── Built-in digit blocks ────────────────────────────────────────────────────
+// These cover the digit systems required by the spec.
+// Additional blocks can be registered via registerLocale().
+
+const BUILTIN_DIGIT_BLOCKS: DigitBlock[] = [
+  [0x0660, 0x0669], // Arabic-Indic (arab)
+  [0x06f0, 0x06f9], // Extended Arabic-Indic / Persian (arabext)
+  [0x0966, 0x096f], // Devanagari / Hindi (deva)
+  [0x09e6, 0x09ef], // Bengali (beng)
+  [0x0e50, 0x0e59], // Thai (thai)
+];
+
+// Mutable registry — locale plugins can add blocks here
+const registeredBlocks: DigitBlock[] = [...BUILTIN_DIGIT_BLOCKS];
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export interface LocaleConfig {
+  /** Extra digit block ranges to register */
+  digitBlocks?: DigitBlock[];
+}
+
+/**
+ * Register additional digit blocks (called by locale plugins as a side effect).
+ * Duplicate ranges are silently ignored.
+ */
+export function registerLocale(config: LocaleConfig): void {
+  if (!config.digitBlocks) return;
+  for (const block of config.digitBlocks) {
+    const already = registeredBlocks.some(
+      ([s]) => s === block[0]
+    );
+    if (!already) registeredBlocks.push(block);
+  }
+}
+
+/**
+ * Normalise any Unicode decimal digit in `input` to its ASCII equivalent (0–9).
+ * Non-digit characters pass through unchanged.
+ */
+export function normalizeDigits(input: string): string {
+  // Fast path: if there are no non-ASCII chars, return as-is
+  if (!/[^\u0020-\u007e]/.test(input)) return input;
+
+  return input.replace(/\p{Nd}/gu, (ch) => {
+    const code = ch.codePointAt(0)!;
+    for (const [start, end] of registeredBlocks) {
+      if (code >= start && code <= end) {
+        return String(code - start);
+      }
+    }
+    // Fallback: let JS try to parse it as a decimal digit
+    const digit = parseInt(ch, 10);
+    return isNaN(digit) ? ch : String(digit);
+  });
+}
+
+/**
+ * Returns true if the character is a non-Latin Unicode decimal digit
+ * (i.e. would need normalization).
+ */
+export function isNonLatinDigit(ch: string): boolean {
+  const code = ch.codePointAt(0);
+  if (code === undefined) return false;
+  if (code >= 0x30 && code <= 0x39) return false; // ASCII 0-9
+  for (const [start, end] of registeredBlocks) {
+    if (code >= start && code <= end) return true;
+  }
+  return false;
+}

--- a/src/core/parser.test.ts
+++ b/src/core/parser.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { createParser } from "./parser.js";
+
+describe("createParser — en-US", () => {
+  const parser = createParser({ locale: "en-US" });
+
+  it("parses plain integer", () => {
+    expect(parser.parse("1234").value).toBe(1234);
+  });
+
+  it("parses formatted number with grouping separator", () => {
+    expect(parser.parse("1,234").value).toBe(1234);
+    expect(parser.parse("1,234,567").value).toBe(1234567);
+  });
+
+  it("parses decimal", () => {
+    expect(parser.parse("1,234.56").value).toBe(1234.56);
+  });
+
+  it("parses negative", () => {
+    expect(parser.parse("-1,234.56").value).toBe(-1234.56);
+  });
+
+  it("parses zero", () => {
+    expect(parser.parse("0").value).toBe(0);
+  });
+
+  it("returns null for empty string", () => {
+    const r = parser.parse("");
+    expect(r.value).toBeNull();
+    expect(r.isValid).toBe(false);
+  });
+
+  it("returns null for garbage input", () => {
+    expect(parser.parse("abc").value).toBeNull();
+  });
+
+  it("identifies intermediate: lone minus", () => {
+    const r = parser.parse("-");
+    expect(r.isIntermediate).toBe(true);
+    expect(r.value).toBeNull();
+  });
+
+  it("identifies intermediate: trailing decimal", () => {
+    const r = parser.parse("1.");
+    expect(r.isIntermediate).toBe(true);
+  });
+
+  it("identifies intermediate: trailing zero", () => {
+    const r = parser.parse("1.0");
+    expect(r.isIntermediate).toBe(true);
+  });
+
+  it("identifies intermediate: trailing zeros", () => {
+    expect(parser.parse("1.00").isIntermediate).toBe(true);
+    expect(parser.parse("1.10").isIntermediate).toBe(true);
+  });
+
+  it("does NOT mark valid complete decimals as intermediate", () => {
+    expect(parser.parse("1.5").isIntermediate).toBe(false);
+    expect(parser.parse("1.5").value).toBe(1.5);
+  });
+});
+
+describe("createParser — de-DE", () => {
+  const parser = createParser({ locale: "de-DE" });
+
+  it("parses de-DE formatted number", () => {
+    expect(parser.parse("1.234,56").value).toBe(1234.56);
+  });
+
+  it("treats ',' as decimal separator", () => {
+    expect(parser.parse("3,14").value).toBe(3.14);
+  });
+
+  it("identifies intermediate: trailing de-DE decimal", () => {
+    expect(parser.parse("1,").isIntermediate).toBe(true);
+  });
+});
+
+describe("createParser — fa-IR with Persian digits", () => {
+  const parser = createParser({ locale: "fa-IR" });
+
+  it("parses Persian digit string", () => {
+    const r = parser.parse("۱۲۳۴");
+    expect(r.value).toBe(1234);
+  });
+
+  it("parses Persian formatted number", () => {
+    // ۱٬۲۳۴٫۵۶ — Persian digits, locale separators
+    const r = parser.parse("۱٬۲۳۴٫۵۶");
+    expect(r.value).toBe(1234.56);
+  });
+});
+
+describe("createParser — allowNegative: false", () => {
+  const parser = createParser({ locale: "en-US", allowNegative: false });
+
+  it("rejects negative numbers", () => {
+    expect(parser.parse("-5").isValid).toBe(false);
+  });
+
+  it("does NOT treat '-' as intermediate", () => {
+    expect(parser.parse("-").isIntermediate).toBe(false);
+  });
+});
+
+describe("createParser — allowDecimal: false", () => {
+  const parser = createParser({ locale: "en-US", allowDecimal: false });
+
+  it("rejects decimal numbers", () => {
+    expect(parser.parse("1.5").isValid).toBe(false);
+  });
+
+  it("does NOT treat '1.' as intermediate", () => {
+    expect(parser.parse("1.").isIntermediate).toBe(false);
+  });
+});
+
+describe("createParser — prefix/suffix", () => {
+  const parser = createParser({ locale: "en-US", prefix: "$", suffix: " USD" });
+
+  it("strips prefix and suffix before parsing", () => {
+    expect(parser.parse("$1,234.56 USD").value).toBe(1234.56);
+  });
+});

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -1,0 +1,174 @@
+import type { ParseResult, LocaleInfo } from "./types.js";
+import { normalizeDigits } from "./normalizer.js";
+import { createFormatter } from "./formatter.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Escape a string so it can be used literally inside a RegExp.
+ */
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Returns true if `s` represents a valid-but-incomplete number:
+ *   "-"       lone minus
+ *   "1."      trailing decimal separator (any locale)
+ *   "1.0"     trailing zero after decimal
+ *   "1.00"    etc.
+ *
+ * These should NOT be reformatted while the user is still typing.
+ */
+function checkIntermediate(
+  normalized: string,
+  info: LocaleInfo,
+  allowNegative: boolean,
+  allowDecimal: boolean
+): boolean {
+  const dec = escapeRegex(info.decimalSeparator);
+  const minus = escapeRegex(info.minusSign);
+
+  // Lone minus sign
+  if (allowNegative && (normalized === "-" || normalized === info.minusSign)) {
+    return true;
+  }
+  // Trailing decimal separator
+  if (allowDecimal && new RegExp(`^${minus}?\\d+${dec}$`).test(normalized)) {
+    return true;
+  }
+  // Trailing zeros after decimal  (e.g. "1.0", "1.00", "-1.0")
+  if (
+    allowDecimal &&
+    new RegExp(`^${minus}?\\d+${dec}\\d*0+$`).test(normalized)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+// ── Factory ───────────────────────────────────────────────────────────────────
+
+export interface ParserOptions {
+  locale?: string;
+  formatOptions?: Intl.NumberFormatOptions;
+  allowNegative?: boolean;
+  allowDecimal?: boolean;
+  prefix?: string;
+  suffix?: string;
+}
+
+export interface Parser {
+  parse(input: string): ParseResult;
+  isIntermediate(input: string): boolean;
+  getLocaleInfo(): LocaleInfo;
+}
+
+/**
+ * Create a locale-aware parser. Separator characters are extracted from
+ * Intl.NumberFormat — never hardcoded.
+ */
+export function createParser(opts: ParserOptions = {}): Parser {
+  const allowNegative = opts.allowNegative ?? true;
+  const allowDecimal = opts.allowDecimal ?? true;
+
+  // Re-use the formatter to get locale info
+  const fmt = createFormatter({
+    locale: opts.locale,
+    formatOptions: opts.formatOptions,
+    prefix: opts.prefix,
+    suffix: opts.suffix,
+  });
+
+  function getLocaleInfo(): LocaleInfo {
+    return fmt.getLocaleInfo();
+  }
+
+  function stripAffordances(raw: string): string {
+    const info = getLocaleInfo();
+
+    // 1. Normalise non-Latin digits to ASCII
+    let s = normalizeDigits(raw);
+
+    // 2. Strip prefix / suffix
+    if (opts.prefix && s.startsWith(opts.prefix)) {
+      s = s.slice(opts.prefix.length);
+    }
+    if (opts.suffix && s.endsWith(opts.suffix)) {
+      s = s.slice(0, -opts.suffix.length);
+    }
+
+    // 3. Strip grouping separators  (escape special chars)
+    if (info.groupingSeparator) {
+      s = s.split(info.groupingSeparator).join("");
+    }
+
+    // 4. Replace locale decimal separator with ASCII "."
+    if (info.decimalSeparator !== ".") {
+      s = s.split(info.decimalSeparator).join(".");
+    }
+
+    // 5. Replace locale minus sign with ASCII "-"
+    if (info.minusSign !== "-") {
+      s = s.split(info.minusSign).join("-");
+    }
+
+    // 6. Strip currency symbol, percent sign, spaces that Intl might prepend/append
+    // Strip any remaining non-numeric chars except digits, ".", "-"
+    // (handles currency prefixes/suffixes from Intl)
+    s = s.replace(/[^\d.\-]/g, "").trim();
+
+    return s;
+  }
+
+  function parse(input: string): ParseResult {
+    if (!input || input.trim() === "") {
+      return { value: null, isValid: false, isIntermediate: false };
+    }
+
+    const info = getLocaleInfo();
+
+    // Check for intermediate state before stripping
+    if (checkIntermediate(input, info, allowNegative, allowDecimal)) {
+      return { value: null, isValid: false, isIntermediate: true };
+    }
+
+    const stripped = stripAffordances(input);
+
+    if (stripped === "") {
+      return { value: null, isValid: false, isIntermediate: false };
+    }
+
+    if (stripped === "-") {
+      // Lone minus after stripping — only intermediate if negatives are allowed
+      return { value: null, isValid: false, isIntermediate: allowNegative };
+    }
+
+    // Reject if not a valid numeric string
+    if (!/^-?\d+\.?\d*$/.test(stripped)) {
+      return { value: null, isValid: false, isIntermediate: false };
+    }
+
+    if (!allowNegative && stripped.startsWith("-")) {
+      return { value: null, isValid: false, isIntermediate: false };
+    }
+
+    if (!allowDecimal && stripped.includes(".")) {
+      return { value: null, isValid: false, isIntermediate: false };
+    }
+
+    const n = parseFloat(stripped);
+    if (!isFinite(n)) {
+      return { value: null, isValid: false, isIntermediate: false };
+    }
+
+    return { value: n, isValid: true, isIntermediate: false };
+  }
+
+  function isIntermediate(input: string): boolean {
+    const info = getLocaleInfo();
+    return checkIntermediate(input, info, allowNegative, allowDecimal);
+  }
+
+  return { parse, isIntermediate, getLocaleInfo };
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,189 @@
+// ── Locale / formatting ──────────────────────────────────────────────────────
+
+export interface LocaleInfo {
+  /** Decimal separator for this locale (e.g. "." en-US, "," de-DE, "٫" fa-IR) */
+  decimalSeparator: string;
+  /** Grouping (thousands) separator (e.g. "," en-US, "." de-DE, "٬" fa-IR) */
+  groupingSeparator: string;
+  /** Minus sign character (usually "-" but can differ) */
+  minusSign: string;
+  /** Locale's representation of "0" (e.g. "0" for Latin, "۰" for Persian) */
+  zero: string;
+  /** Whether this is an RTL locale */
+  isRTL: boolean;
+}
+
+export interface FormatResult {
+  formatted: string;
+  parts: Intl.NumberFormatPart[];
+}
+
+// ── Parsing ──────────────────────────────────────────────────────────────────
+
+export interface ParseResult {
+  /** The parsed number, or null if empty / un-parseable */
+  value: number | null;
+  /** True for valid numbers */
+  isValid: boolean;
+  /**
+   * True for valid-but-incomplete input that must not be reformatted yet:
+   * "-", "1.", "1.0", "1.00", etc.
+   */
+  isIntermediate: boolean;
+}
+
+// ── Cursor ───────────────────────────────────────────────────────────────────
+
+/**
+ * boolean[] of length formattedValue.length + 1.
+ * true  → cursor may rest at this index
+ * false → cursor must not rest here (e.g. inside a thousands separator)
+ */
+export type CaretBoundary = boolean[];
+
+// ── Normalizer ───────────────────────────────────────────────────────────────
+
+/** Unicode codepoint range [start, end] inclusive representing a digit block */
+export type DigitBlock = readonly [number, number];
+
+// ── State options ─────────────────────────────────────────────────────────────
+
+export interface UseNumberFieldStateOptions {
+  /** Controlled numeric value */
+  value?: number | null;
+  /** Uncontrolled default value */
+  defaultValue?: number | null;
+  /** Fires on every meaningful value change */
+  onChange?: (value: number | null) => void;
+  /** BCP 47 locale tag (default: browser locale) */
+  locale?: string;
+  /** Full Intl.NumberFormatOptions — currency, percent, decimal, etc. */
+  formatOptions?: Intl.NumberFormatOptions;
+  /** Minimum allowed value */
+  minValue?: number;
+  /** Maximum allowed value */
+  maxValue?: number;
+  /** Step amount for increment/decrement (default: 1) */
+  step?: number;
+  /** Large step — Shift+Arrow / PageUp/Down (default: step * 10) */
+  largeStep?: number;
+  /** Small step — Meta/Ctrl+Arrow (default: step * 0.1) */
+  smallStep?: number;
+  /** Allow negative values (default: true) */
+  allowNegative?: boolean;
+  /** Allow decimal values (default: true) */
+  allowDecimal?: boolean;
+  /** Override maximumFractionDigits from formatOptions */
+  maximumFractionDigits?: number;
+  /** Override minimumFractionDigits from formatOptions */
+  minimumFractionDigits?: number;
+  /** Always show exactly maximumFractionDigits decimal places */
+  fixedDecimalScale?: boolean;
+  /** When clamping happens (default: "blur") */
+  clampBehavior?: "blur" | "strict" | "none";
+  /** Apply live formatting while typing (default: true) */
+  liveFormat?: boolean;
+  /** Arbitrary prefix string (e.g. "$") */
+  prefix?: string;
+  /** Arbitrary suffix string (e.g. " تومان") */
+  suffix?: string;
+  /** Disable the field */
+  disabled?: boolean;
+  /** Make the field read-only */
+  readOnly?: boolean;
+  /** Mark the field as required */
+  required?: boolean;
+}
+
+// ── State ─────────────────────────────────────────────────────────────────────
+
+export interface NumberFieldState {
+  /** The display string shown in the input */
+  inputValue: string;
+  /** The parsed numeric value (null for empty/invalid) */
+  numberValue: number | null;
+  /** Whether increment is currently possible */
+  canIncrement: boolean;
+  /** Whether decrement is currently possible */
+  canDecrement: boolean;
+  /** Update display string (triggers parse + onChange) */
+  setInputValue: (val: string) => void;
+  /** Directly set the numeric value (triggers format + onChange) */
+  setNumberValue: (val: number | null) => void;
+  /** Format + clamp on blur — call from onBlur */
+  commit: () => void;
+  /** Increment by step */
+  increment: (amount?: number) => void;
+  /** Decrement by step */
+  decrement: (amount?: number) => void;
+  /** Jump to maxValue */
+  incrementToMax: () => void;
+  /** Jump to minValue */
+  decrementToMin: () => void;
+  /** Raw options (for hooks that need them) */
+  options: UseNumberFieldStateOptions;
+}
+
+// ── Hook API ─────────────────────────────────────────────────────────────────
+
+export interface UseNumberFieldProps extends UseNumberFieldStateOptions {
+  /** Visible label text (used for aria-label fallback) */
+  label?: string;
+  "aria-label"?: string;
+  "aria-describedby"?: string;
+  "aria-labelledby"?: string;
+  /** Form field name — renders a hidden input */
+  name?: string;
+  /** id for the input element */
+  id?: string;
+  /** Enable mouse-wheel increment/decrement */
+  allowMouseWheel?: boolean;
+  onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void;
+  onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
+}
+
+export interface NumberFieldAria {
+  labelProps: React.LabelHTMLAttributes<HTMLLabelElement>;
+  groupProps: React.HTMLAttributes<HTMLDivElement>;
+  inputProps: React.InputHTMLAttributes<HTMLInputElement>;
+  hiddenInputProps: React.InputHTMLAttributes<HTMLInputElement> | null;
+  incrementButtonProps: React.ButtonHTMLAttributes<HTMLButtonElement>;
+  decrementButtonProps: React.ButtonHTMLAttributes<HTMLButtonElement>;
+}
+
+// ── Component API ─────────────────────────────────────────────────────────────
+
+export type StateRenderFn = (
+  props: Record<string, unknown>,
+  state: NumberFieldState
+) => React.ReactElement;
+
+export type RenderProp =
+  | React.ReactElement
+  | StateRenderFn;
+
+export interface NumberFieldRootProps extends UseNumberFieldProps {
+  children?: React.ReactNode;
+  /** Fires on every meaningful value change */
+  onValueChange?: (
+    value: number | null,
+    details: {
+      reason:
+        | "input"
+        | "clear"
+        | "blur"
+        | "paste"
+        | "keyboard"
+        | "increment"
+        | "decrement"
+        | "wheel";
+      formattedValue: string;
+      event?: React.SyntheticEvent;
+    }
+  ) => void;
+  /** Fires only on commit (blur, Enter) */
+  onValueCommitted?: (
+    value: number | null,
+    details: { reason: "blur" | "keyboard" }
+  ) => void;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,45 @@
+"use client";
+
+// ── Hooks ─────────────────────────────────────────────────────────────────────
+export { useNumberFieldState } from "./react/useNumberFieldState.js";
+export { useNumberField } from "./react/useNumberField.js";
+export { useControllableState } from "./react/useControllableState.js";
+
+// ── Components ────────────────────────────────────────────────────────────────
+export { NumberField } from "./react/NumberField.js";
+
+// ── Context ───────────────────────────────────────────────────────────────────
+export {
+  NumberFieldContext,
+  useNumberFieldContext,
+} from "./react/context.js";
+export type { NumberFieldContextValue } from "./react/context.js";
+
+// ── Core (tree-shakeable) ─────────────────────────────────────────────────────
+export { createFormatter } from "./core/formatter.js";
+export { createParser } from "./core/parser.js";
+export {
+  normalizeDigits,
+  isNonLatinDigit,
+  registerLocale,
+} from "./core/normalizer.js";
+export { getCaretBoundary, computeNewCursorPosition } from "./core/cursor.js";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+export type {
+  LocaleInfo,
+  FormatResult,
+  ParseResult,
+  CaretBoundary,
+  DigitBlock,
+  UseNumberFieldStateOptions,
+  NumberFieldState,
+  UseNumberFieldProps,
+  NumberFieldAria,
+  NumberFieldRootProps,
+  RenderProp,
+  StateRenderFn,
+} from "./core/types.js";
+export type { FormatterOptions, Formatter } from "./core/formatter.js";
+export type { ParserOptions, Parser } from "./core/parser.js";
+export type { LocaleConfig } from "./core/normalizer.js";

--- a/src/locales/ar.ts
+++ b/src/locales/ar.ts
@@ -1,0 +1,15 @@
+/**
+ * Arabic (ar) locale plugin.
+ *
+ * Registers Arabic-Indic digit block (U+0660–U+0669).
+ *
+ * Usage:
+ *   import 'numra/locales/ar'
+ */
+import { registerLocale } from "../core/normalizer.js";
+
+registerLocale({
+  digitBlocks: [
+    [0x0660, 0x0669], // Arabic-Indic ٠–٩
+  ],
+});

--- a/src/locales/bn.ts
+++ b/src/locales/bn.ts
@@ -1,0 +1,15 @@
+/**
+ * Bengali (bn-BD / bn-IN) locale plugin.
+ *
+ * Registers Bengali digit block (U+09E6–U+09EF).
+ *
+ * Usage:
+ *   import 'numra/locales/bn'
+ */
+import { registerLocale } from "../core/normalizer.js";
+
+registerLocale({
+  digitBlocks: [
+    [0x09e6, 0x09ef], // Bengali ০–৯
+  ],
+});

--- a/src/locales/fa.ts
+++ b/src/locales/fa.ts
@@ -1,0 +1,21 @@
+/**
+ * Persian (fa-IR) locale plugin.
+ *
+ * Registers Extended Arabic-Indic digit block (U+06F0–U+06F9).
+ * The ISIRI 9147 keyboard produces these codepoints when number keys are
+ * pressed on a Persian layout. This side-effect import enables their
+ * normalization to ASCII 0–9 before parsing.
+ *
+ * Also registers the Arabic-Indic block for mixed-input scenarios.
+ *
+ * Usage:
+ *   import 'numra/locales/fa'
+ */
+import { registerLocale } from "../core/normalizer.js";
+
+registerLocale({
+  digitBlocks: [
+    [0x06f0, 0x06f9], // Extended Arabic-Indic (Persian) ۰–۹
+    [0x0660, 0x0669], // Arabic-Indic ٠–٩
+  ],
+});

--- a/src/locales/hi.ts
+++ b/src/locales/hi.ts
@@ -1,0 +1,15 @@
+/**
+ * Hindi / Devanagari (hi-IN) locale plugin.
+ *
+ * Registers Devanagari digit block (U+0966–U+096F).
+ *
+ * Usage:
+ *   import 'numra/locales/hi'
+ */
+import { registerLocale } from "../core/normalizer.js";
+
+registerLocale({
+  digitBlocks: [
+    [0x0966, 0x096f], // Devanagari ०–९
+  ],
+});

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -1,0 +1,12 @@
+/**
+ * All locale plugins — import this to register support for
+ * Persian, Arabic, Bengali, Hindi, and Thai digit systems in one shot.
+ *
+ * Usage:
+ *   import 'numra/locales'
+ */
+export * from "./fa.js";
+export * from "./ar.js";
+export * from "./bn.js";
+export * from "./hi.js";
+export * from "./th.js";

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -1,0 +1,15 @@
+/**
+ * Thai (th-TH) locale plugin.
+ *
+ * Registers Thai digit block (U+0E50–U+0E59).
+ *
+ * Usage:
+ *   import 'numra/locales/th'
+ */
+import { registerLocale } from "../core/normalizer.js";
+
+registerLocale({
+  digitBlocks: [
+    [0x0e50, 0x0e59], // Thai ๐–๙
+  ],
+});

--- a/src/react/NumberField.test.tsx
+++ b/src/react/NumberField.test.tsx
@@ -1,0 +1,260 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NumberField } from "./NumberField.js";
+
+// Helper that renders a standard NumberField
+function renderField(props: Parameters<typeof NumberField.Root>[0] = {}) {
+  return render(
+    <NumberField.Root {...props}>
+      <NumberField.Label>Amount</NumberField.Label>
+      <NumberField.Group>
+        <NumberField.Decrement data-testid="decrement" />
+        <NumberField.Input data-testid="input" />
+        <NumberField.Increment data-testid="increment" />
+      </NumberField.Group>
+    </NumberField.Root>
+  );
+}
+
+describe("NumberField.Root", () => {
+  it("renders without crashing", () => {
+    renderField();
+    expect(screen.getByTestId("input")).toBeInTheDocument();
+  });
+
+  it("renders label and associates it with input", () => {
+    renderField();
+    const label = screen.getByText("Amount");
+    const input = screen.getByTestId("input");
+    expect(label).toBeInTheDocument();
+    // Label should point to input via htmlFor
+    expect(label.getAttribute("for")).toBe(input.getAttribute("id"));
+  });
+
+  it("renders increment and decrement buttons", () => {
+    renderField();
+    expect(screen.getByTestId("increment")).toBeInTheDocument();
+    expect(screen.getByTestId("decrement")).toBeInTheDocument();
+  });
+});
+
+describe("NumberField ARIA attributes", () => {
+  it("has role spinbutton", () => {
+    renderField();
+    expect(screen.getByRole("spinbutton")).toBeInTheDocument();
+  });
+
+  it("sets aria-valuenow from defaultValue", () => {
+    renderField({ defaultValue: 42, locale: "en-US" });
+    expect(screen.getByRole("spinbutton")).toHaveAttribute(
+      "aria-valuenow",
+      "42"
+    );
+  });
+
+  it("sets aria-valuemin and aria-valuemax", () => {
+    renderField({ minValue: 0, maxValue: 100, locale: "en-US" });
+    const input = screen.getByRole("spinbutton");
+    expect(input).toHaveAttribute("aria-valuemin", "0");
+    expect(input).toHaveAttribute("aria-valuemax", "100");
+  });
+
+  it("sets aria-disabled when disabled", () => {
+    renderField({ disabled: true });
+    expect(screen.getByRole("spinbutton")).toHaveAttribute("aria-disabled");
+  });
+
+  it("sets aria-readonly when readOnly", () => {
+    renderField({ readOnly: true });
+    expect(screen.getByRole("spinbutton")).toHaveAttribute("aria-readonly");
+  });
+
+  it("sets aria-required when required", () => {
+    renderField({ required: true });
+    expect(screen.getByRole("spinbutton")).toHaveAttribute("aria-required");
+  });
+});
+
+describe("NumberField input type", () => {
+  it("is type=text with inputmode=decimal", () => {
+    renderField();
+    const input = screen.getByTestId("input");
+    expect(input).toHaveAttribute("type", "text");
+    expect(input).toHaveAttribute("inputmode", "decimal");
+  });
+});
+
+describe("NumberField keyboard interactions", () => {
+  it("increments on ArrowUp", async () => {
+    const user = userEvent.setup();
+    renderField({ defaultValue: 5, locale: "en-US" });
+    const input = screen.getByRole("spinbutton");
+    await user.click(input);
+    await user.keyboard("{ArrowUp}");
+    expect(input).toHaveValue("6");
+  });
+
+  it("decrements on ArrowDown", async () => {
+    const user = userEvent.setup();
+    renderField({ defaultValue: 5, locale: "en-US" });
+    const input = screen.getByRole("spinbutton");
+    await user.click(input);
+    await user.keyboard("{ArrowDown}");
+    expect(input).toHaveValue("4");
+  });
+
+  it("increments by largeStep on Shift+ArrowUp", async () => {
+    const user = userEvent.setup();
+    renderField({ defaultValue: 5, locale: "en-US", step: 1 });
+    const input = screen.getByRole("spinbutton");
+    await user.click(input);
+    await user.keyboard("{Shift>}{ArrowUp}{/Shift}");
+    expect(input).toHaveValue("15"); // largeStep = 10
+  });
+
+  it("decrements by largeStep on Shift+ArrowDown", async () => {
+    const user = userEvent.setup();
+    renderField({ defaultValue: 50, locale: "en-US", step: 1 });
+    const input = screen.getByRole("spinbutton");
+    await user.click(input);
+    await user.keyboard("{Shift>}{ArrowDown}{/Shift}");
+    expect(input).toHaveValue("40");
+  });
+
+  it("goes to min on Home key", async () => {
+    const user = userEvent.setup();
+    renderField({ defaultValue: 50, locale: "en-US", minValue: 0, maxValue: 100 });
+    const input = screen.getByRole("spinbutton");
+    await user.click(input);
+    await user.keyboard("{Home}");
+    expect(input).toHaveValue("0");
+  });
+
+  it("goes to max on End key", async () => {
+    const user = userEvent.setup();
+    renderField({ defaultValue: 50, locale: "en-US", minValue: 0, maxValue: 100 });
+    const input = screen.getByRole("spinbutton");
+    await user.click(input);
+    await user.keyboard("{End}");
+    expect(input).toHaveValue("100");
+  });
+
+  it("increments by largeStep on PageUp", async () => {
+    const user = userEvent.setup();
+    renderField({ defaultValue: 5, locale: "en-US", step: 1 });
+    const input = screen.getByRole("spinbutton");
+    await user.click(input);
+    await user.keyboard("{PageUp}");
+    expect(input).toHaveValue("15");
+  });
+
+  it("decrements by largeStep on PageDown", async () => {
+    const user = userEvent.setup();
+    renderField({ defaultValue: 50, locale: "en-US", step: 1 });
+    const input = screen.getByRole("spinbutton");
+    await user.click(input);
+    await user.keyboard("{PageDown}");
+    expect(input).toHaveValue("40");
+  });
+});
+
+describe("NumberField button interactions", () => {
+  it("increments when increment button is clicked", async () => {
+    const user = userEvent.setup();
+    renderField({ defaultValue: 5, locale: "en-US" });
+    await user.click(screen.getByTestId("increment"));
+    expect(screen.getByRole("spinbutton")).toHaveValue("6");
+  });
+
+  it("decrements when decrement button is clicked", async () => {
+    const user = userEvent.setup();
+    renderField({ defaultValue: 5, locale: "en-US" });
+    await user.click(screen.getByTestId("decrement"));
+    expect(screen.getByRole("spinbutton")).toHaveValue("4");
+  });
+
+  it("disables increment button at maxValue", () => {
+    renderField({ defaultValue: 10, maxValue: 10, locale: "en-US" });
+    expect(screen.getByTestId("increment")).toBeDisabled();
+  });
+
+  it("disables decrement button at minValue", () => {
+    renderField({ defaultValue: 0, minValue: 0, locale: "en-US" });
+    expect(screen.getByTestId("decrement")).toBeDisabled();
+  });
+});
+
+describe("NumberField form integration", () => {
+  it("renders hidden input when name is provided", () => {
+    render(
+      <NumberField.Root name="price" defaultValue={42} locale="en-US">
+        <NumberField.Input data-testid="input" />
+        <NumberField.HiddenInput />
+      </NumberField.Root>
+    );
+    const hidden = document.querySelector("input[type=hidden]");
+    expect(hidden).toBeInTheDocument();
+    expect(hidden).toHaveAttribute("name", "price");
+    expect(hidden).toHaveAttribute("value", "42");
+  });
+
+  it("does NOT render hidden input when no name", () => {
+    render(
+      <NumberField.Root defaultValue={42} locale="en-US">
+        <NumberField.Input data-testid="input" />
+        <NumberField.HiddenInput />
+      </NumberField.Root>
+    );
+    expect(document.querySelector("input[type=hidden]")).toBeNull();
+  });
+});
+
+describe("NumberField blur behavior", () => {
+  it("commits and re-formats on blur", async () => {
+    const user = userEvent.setup();
+    renderField({ locale: "en-US" });
+    const input = screen.getByRole("spinbutton");
+    await user.click(input);
+    // Type raw digits — liveFormat will format them
+    await user.keyboard("1234");
+    // Should show formatted value
+    expect(input.getAttribute("value")).toContain("1");
+  });
+});
+
+describe("NumberField render prop", () => {
+  it("renders custom element via render prop (element form)", () => {
+    render(
+      <NumberField.Root locale="en-US">
+        <NumberField.Increment
+          render={<button data-testid="custom-btn" />}
+        >
+          up
+        </NumberField.Increment>
+      </NumberField.Root>
+    );
+    expect(screen.getByTestId("custom-btn")).toBeInTheDocument();
+  });
+});
+
+describe("NumberField disabled", () => {
+  it("disables the input", () => {
+    renderField({ disabled: true });
+    expect(screen.getByRole("spinbutton")).toBeDisabled();
+  });
+
+  it("disables increment and decrement buttons", () => {
+    renderField({ disabled: true });
+    expect(screen.getByTestId("increment")).toBeDisabled();
+    expect(screen.getByTestId("decrement")).toBeDisabled();
+  });
+});
+
+describe("NumberField data attributes", () => {
+  it("sets data-disabled on root when disabled", () => {
+    const { container } = renderField({ disabled: true });
+    const root = container.firstChild as HTMLElement;
+    expect(root.getAttribute("data-disabled")).toBe("");
+  });
+});

--- a/src/react/NumberField.tsx
+++ b/src/react/NumberField.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import React, { forwardRef, useRef } from "react";
+import type {
+  NumberFieldRootProps,
+  NumberFieldState,
+  RenderProp,
+} from "../core/types.js";
+import { NumberFieldContext, useNumberFieldContext } from "./context.js";
+import { useNumberFieldState } from "./useNumberFieldState.js";
+import { useNumberField } from "./useNumberField.js";
+
+// ── Render prop utility ───────────────────────────────────────────────────────
+
+/**
+ * Merge component props with a `render` prop.
+ * Accepts either a React element or a render function.
+ */
+function renderWith(
+  defaultElement: React.ReactElement,
+  render: RenderProp | undefined,
+  state: NumberFieldState
+): React.ReactElement {
+  if (!render) return defaultElement;
+
+  if (typeof render === "function") {
+    return render(defaultElement.props as Record<string, unknown>, state);
+  }
+
+  // Element form: clone with merged props
+  return React.cloneElement(render, Object.assign(
+    {},
+    defaultElement.props as Record<string, unknown>,
+    render.props as Record<string, unknown>
+  ));
+}
+
+// ── Data attributes helper ────────────────────────────────────────────────────
+
+function stateDataAttrs(state: NumberFieldState): Record<string, string | undefined> {
+  const { options } = state;
+  return {
+    "data-disabled": options.disabled ? "" : undefined,
+    "data-readonly": options.readOnly ? "" : undefined,
+    "data-required": options.required ? "" : undefined,
+  };
+}
+
+// ── Root ──────────────────────────────────────────────────────────────────────
+
+const Root = forwardRef<HTMLDivElement, NumberFieldRootProps>(
+  function NumberFieldRoot({ children, onValueChange, onValueCommitted, ...props }, ref) {
+    const inputRef = useRef<HTMLInputElement | null>(null);
+
+    // Wrap onChange to also fire onValueChange with details
+    const wrappedProps = {
+      ...props,
+      onChange: (value: number | null) => {
+        props.onChange?.(value);
+        onValueChange?.(value, {
+          reason: "input",
+          formattedValue: "",
+        });
+      },
+    };
+
+    const state = useNumberFieldState(wrappedProps);
+    const aria = useNumberField(wrappedProps, state, inputRef);
+
+    return (
+      <NumberFieldContext.Provider value={{ state, aria, inputRef, props: wrappedProps }}>
+        <div ref={ref} {...stateDataAttrs(state)}>
+          {children}
+        </div>
+      </NumberFieldContext.Provider>
+    );
+  }
+);
+
+// ── Label ─────────────────────────────────────────────────────────────────────
+
+interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
+  render?: RenderProp;
+  children?: React.ReactNode;
+}
+
+const Label = forwardRef<HTMLLabelElement, LabelProps>(
+  function NumberFieldLabel({ render, children, ...rest }, ref) {
+    const { aria, state } = useNumberFieldContext();
+    const el = (
+      <label ref={ref} {...aria.labelProps} {...rest}>
+        {children}
+      </label>
+    );
+    return renderWith(el, render, state);
+  }
+);
+
+// ── Group ─────────────────────────────────────────────────────────────────────
+
+interface GroupProps extends React.HTMLAttributes<HTMLDivElement> {
+  render?: RenderProp;
+  children?: React.ReactNode;
+}
+
+const Group = forwardRef<HTMLDivElement, GroupProps>(
+  function NumberFieldGroup({ render, children, ...rest }, ref) {
+    const { aria, state } = useNumberFieldContext();
+    const el = (
+      <div ref={ref} {...aria.groupProps} {...rest}>
+        {children}
+      </div>
+    );
+    return renderWith(el, render, state);
+  }
+);
+
+// ── Input ─────────────────────────────────────────────────────────────────────
+
+interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "type"> {
+  render?: RenderProp;
+}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  function NumberFieldInput({ render, ...rest }, _ref) {
+    const { aria, state, inputRef } = useNumberFieldContext();
+    const el = (
+      <input ref={inputRef} {...aria.inputProps} {...rest} />
+    );
+    return renderWith(el, render, state);
+  }
+);
+
+// ── Increment ─────────────────────────────────────────────────────────────────
+
+interface IncrementProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  render?: RenderProp;
+  children?: React.ReactNode;
+}
+
+const Increment = forwardRef<HTMLButtonElement, IncrementProps>(
+  function NumberFieldIncrement({ render, children, ...rest }, ref) {
+    const { aria, state } = useNumberFieldContext();
+    const el = (
+      <button ref={ref} {...aria.incrementButtonProps} {...rest}>
+        {children ?? "+"}
+      </button>
+    );
+    return renderWith(el, render, state);
+  }
+);
+
+// ── Decrement ─────────────────────────────────────────────────────────────────
+
+interface DecrementProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  render?: RenderProp;
+  children?: React.ReactNode;
+}
+
+const Decrement = forwardRef<HTMLButtonElement, DecrementProps>(
+  function NumberFieldDecrement({ render, children, ...rest }, ref) {
+    const { aria, state } = useNumberFieldContext();
+    const el = (
+      <button ref={ref} {...aria.decrementButtonProps} {...rest}>
+        {children ?? "−"}
+      </button>
+    );
+    return renderWith(el, render, state);
+  }
+);
+
+// ── HiddenInput ───────────────────────────────────────────────────────────────
+
+const HiddenInput = function NumberFieldHiddenInput() {
+  const { aria } = useNumberFieldContext();
+  if (!aria.hiddenInputProps) return null;
+  return <input {...aria.hiddenInputProps} />;
+};
+
+// ── Namespace export ──────────────────────────────────────────────────────────
+
+export const NumberField = {
+  Root,
+  Label,
+  Group,
+  Input,
+  Increment,
+  Decrement,
+  HiddenInput,
+};

--- a/src/react/context.ts
+++ b/src/react/context.ts
@@ -1,0 +1,27 @@
+import { createContext, useContext } from "react";
+import type { RefObject } from "react";
+import type { NumberFieldState, NumberFieldAria, UseNumberFieldProps } from "../core/types.js";
+
+export interface NumberFieldContextValue {
+  state: NumberFieldState;
+  aria: NumberFieldAria;
+  inputRef: RefObject<HTMLInputElement | null>;
+  props: UseNumberFieldProps;
+}
+
+export const NumberFieldContext =
+  createContext<NumberFieldContextValue | null>(null);
+
+/**
+ * Hook for sub-components to access the NumberField context.
+ * Throws if used outside NumberField.Root.
+ */
+export function useNumberFieldContext(): NumberFieldContextValue {
+  const ctx = useContext(NumberFieldContext);
+  if (!ctx) {
+    throw new Error(
+      "[numra] NumberField sub-components must be used inside <NumberField.Root>."
+    );
+  }
+  return ctx;
+}

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,0 +1,6 @@
+export { useControllableState } from "./useControllableState.js";
+export { useNumberFieldState } from "./useNumberFieldState.js";
+export { useNumberField } from "./useNumberField.js";
+export { NumberField } from "./NumberField.js";
+export { NumberFieldContext, useNumberFieldContext } from "./context.js";
+export type { NumberFieldContextValue } from "./context.js";

--- a/src/react/useControllableState.ts
+++ b/src/react/useControllableState.ts
@@ -1,0 +1,55 @@
+import { useCallback, useRef, useState } from "react";
+
+interface UseControllableStateOptions<T> {
+  value?: T;
+  defaultValue?: T;
+  onChange?: (value: T) => void;
+}
+
+/**
+ * Manages controlled vs uncontrolled state.
+ * - If `value` is provided, the component is controlled.
+ * - Otherwise it manages its own state starting from `defaultValue`.
+ * Warns in dev mode if the component switches between controlled/uncontrolled.
+ */
+export function useControllableState<T>({
+  value,
+  defaultValue,
+  onChange,
+}: UseControllableStateOptions<T>): [T | undefined, (next: T | ((prev: T | undefined) => T)) => void] {
+  const isControlled = value !== undefined;
+  const wasControlled = useRef(isControlled);
+
+  if (typeof window !== "undefined" && (window as unknown as { __DEV__?: boolean }).__DEV__ !== false) {
+    if (wasControlled.current !== isControlled) {
+      console.warn(
+        `[numra] Component is changing from ${
+          wasControlled.current ? "controlled" : "uncontrolled"
+        } to ${isControlled ? "controlled" : "uncontrolled"}. ` +
+          "Decide between using a controlled or uncontrolled component and don't switch."
+      );
+    }
+  }
+
+  const [internalValue, setInternalValue] = useState<T | undefined>(
+    defaultValue
+  );
+
+  const set = useCallback(
+    (next: T | ((prev: T | undefined) => T)) => {
+      const nextValue =
+        typeof next === "function"
+          ? (next as (prev: T | undefined) => T)(isControlled ? value : internalValue)
+          : next;
+
+      if (!isControlled) {
+        setInternalValue(nextValue);
+      }
+      onChange?.(nextValue);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isControlled, value, internalValue, onChange]
+  );
+
+  return [isControlled ? value : internalValue, set];
+}

--- a/src/react/useNumberField.ts
+++ b/src/react/useNumberField.ts
@@ -1,0 +1,317 @@
+import { useCallback, useId, useLayoutEffect, useMemo, useRef } from "react";
+import type { NumberFieldAria, NumberFieldState, UseNumberFieldProps } from "../core/types.js";
+import { createFormatter } from "../core/formatter.js";
+import { createParser } from "../core/parser.js";
+import { computeNewCursorPosition } from "../core/cursor.js";
+import { normalizeDigits } from "../core/normalizer.js";
+
+export function useNumberField(
+  props: UseNumberFieldProps,
+  state: NumberFieldState,
+  inputRef: React.RefObject<HTMLInputElement | null>
+): NumberFieldAria {
+  const {
+    locale,
+    formatOptions,
+    minValue,
+    maxValue,
+    allowNegative = true,
+    allowDecimal = true,
+    allowMouseWheel = false,
+    liveFormat = true,
+    prefix,
+    suffix,
+    name,
+    disabled,
+    readOnly,
+    required,
+    onFocus,
+    onBlur,
+    maximumFractionDigits,
+    minimumFractionDigits,
+    fixedDecimalScale,
+  } = props;
+
+  const {
+    step = 1,
+    largeStep = step * 10,
+    smallStep = step * 0.1,
+  } = state.options;
+
+  const autoId = useId();
+  const inputId = props.id ?? `numra-${autoId}`;
+  const labelId = `${inputId}-label`;
+
+  // ── Formatter & parser (kept in sync with state's) ──────────────────────
+  const formatter = useMemo(
+    () =>
+      createFormatter({
+        locale,
+        formatOptions,
+        prefix,
+        suffix,
+        minimumFractionDigits,
+        maximumFractionDigits,
+        fixedDecimalScale,
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [locale, JSON.stringify(formatOptions), prefix, suffix, minimumFractionDigits, maximumFractionDigits, fixedDecimalScale]
+  );
+
+  const parser = useMemo(
+    () =>
+      createParser({
+        locale,
+        formatOptions,
+        allowNegative,
+        allowDecimal,
+        prefix,
+        suffix,
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [locale, JSON.stringify(formatOptions), allowNegative, allowDecimal, prefix, suffix]
+  );
+
+  // ── Cursor engine ────────────────────────────────────────────────────────
+  const pendingCursor = useRef<number | null>(null);
+
+  // Restore cursor synchronously after React commits the new value to DOM
+  useLayoutEffect(() => {
+    if (
+      pendingCursor.current !== null &&
+      inputRef.current &&
+      document.activeElement === inputRef.current
+    ) {
+      inputRef.current.setSelectionRange(
+        pendingCursor.current,
+        pendingCursor.current
+      );
+      pendingCursor.current = null;
+    }
+  // Run after every inputValue change
+  }, [state.inputValue, inputRef]);
+
+  // ── onChange handler ─────────────────────────────────────────────────────
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const rawValue = e.target.value;
+      const cursorPos = e.target.selectionStart ?? rawValue.length;
+      const inputType = (e.nativeEvent as InputEvent).inputType;
+      const info = formatter.getLocaleInfo();
+
+      // Normalise non-Latin digits
+      const normalized = normalizeDigits(rawValue);
+
+      let displayValue: string;
+
+      if (liveFormat) {
+        const result = parser.parse(normalized);
+
+        if (result.isIntermediate) {
+          // Preserve intermediate states (lone "-", trailing "1.", etc.)
+          displayValue = normalized;
+        } else if (result.value !== null) {
+          displayValue = formatter.format(result.value);
+        } else if (normalized === "") {
+          displayValue = "";
+        } else {
+          // Invalid input — keep the raw normalised string so the user can
+          // see what they typed (they'll get corrected on blur)
+          displayValue = normalized;
+        }
+
+        // Compute and stash cursor position for useLayoutEffect
+        pendingCursor.current = computeNewCursorPosition(
+          rawValue,
+          cursorPos,
+          displayValue,
+          info,
+          inputType
+        );
+      } else {
+        // No live format — just pass through normalised digits
+        displayValue = normalized;
+        pendingCursor.current = cursorPos;
+      }
+
+      state.setInputValue(displayValue);
+    },
+    [formatter, parser, liveFormat, state]
+  );
+
+  // ── Keyboard handler ─────────────────────────────────────────────────────
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (disabled || readOnly) return;
+
+      const key = e.key;
+
+      if (key === "ArrowUp" || key === "ArrowDown") {
+        e.preventDefault();
+        const direction = key === "ArrowUp" ? 1 : -1;
+        if (e.shiftKey) {
+          direction > 0 ? state.increment(largeStep) : state.decrement(largeStep);
+        } else if (e.metaKey || e.ctrlKey) {
+          direction > 0 ? state.increment(smallStep) : state.decrement(smallStep);
+        } else {
+          direction > 0 ? state.increment() : state.decrement();
+        }
+        return;
+      }
+
+      if (key === "PageUp") {
+        e.preventDefault();
+        state.increment(largeStep);
+        return;
+      }
+
+      if (key === "PageDown") {
+        e.preventDefault();
+        state.decrement(largeStep);
+        return;
+      }
+
+      if (key === "Home") {
+        if (minValue !== undefined) {
+          e.preventDefault();
+          state.decrementToMin();
+        }
+        return;
+      }
+
+      if (key === "End") {
+        if (maxValue !== undefined) {
+          e.preventDefault();
+          state.incrementToMax();
+        }
+        return;
+      }
+
+      if (key === "Enter") {
+        state.commit();
+        return;
+      }
+    },
+    [disabled, readOnly, state, largeStep, smallStep, minValue, maxValue]
+  );
+
+  // ── Wheel handler ────────────────────────────────────────────────────────
+  const handleWheel = useCallback(
+    (e: React.WheelEvent<HTMLInputElement>) => {
+      if (!allowMouseWheel || disabled || readOnly) return;
+      if (document.activeElement !== inputRef.current) return;
+      e.preventDefault();
+      if (e.deltaY < 0) {
+        state.increment();
+      } else {
+        state.decrement();
+      }
+    },
+    [allowMouseWheel, disabled, readOnly, state, inputRef]
+  );
+
+  // ── Blur handler ─────────────────────────────────────────────────────────
+  const handleBlur = useCallback(
+    (e: React.FocusEvent<HTMLInputElement>) => {
+      state.commit();
+      onBlur?.(e);
+    },
+    [state, onBlur]
+  );
+
+  // ── ARIA valuetext ───────────────────────────────────────────────────────
+  // Use a more verbose description for screen readers.
+  const ariaValueText = useMemo(() => {
+    if (state.numberValue == null) return undefined;
+    return formatter.format(state.numberValue);
+  }, [state.numberValue, formatter]);
+
+  // ── RTL detection ────────────────────────────────────────────────────────
+  const localeInfo = formatter.getLocaleInfo();
+
+  // ── Prop maps ────────────────────────────────────────────────────────────
+
+  const labelProps: React.LabelHTMLAttributes<HTMLLabelElement> = {
+    id: labelId,
+    htmlFor: inputId,
+  };
+
+  const groupProps: React.HTMLAttributes<HTMLDivElement> = {
+    role: "group",
+    "aria-labelledby": props["aria-labelledby"] ?? labelId,
+  };
+
+  const inputProps: React.InputHTMLAttributes<HTMLInputElement> = {
+    id: inputId,
+    type: "text",
+    inputMode: "decimal",
+    role: "spinbutton",
+    autoComplete: "off",
+    autoCorrect: "off",
+    spellCheck: false,
+    "aria-label": props["aria-label"],
+    "aria-labelledby": props["aria-labelledby"] ?? labelId,
+    "aria-describedby": props["aria-describedby"],
+    "aria-valuenow": state.numberValue ?? undefined,
+    "aria-valuemin": minValue,
+    "aria-valuemax": maxValue,
+    "aria-valuetext": ariaValueText,
+    "aria-disabled": disabled || undefined,
+    "aria-readonly": readOnly || undefined,
+    "aria-required": required || undefined,
+    disabled,
+    readOnly,
+    required,
+    value: state.inputValue,
+    onChange: handleChange,
+    onKeyDown: handleKeyDown,
+    onBlur: handleBlur,
+    onFocus: onFocus as React.FocusEventHandler<HTMLInputElement>,
+    onWheel: allowMouseWheel ? handleWheel : undefined,
+    // RTL: numbers are always LTR, align-right in RTL contexts
+    style: localeInfo.isRTL
+      ? { direction: "ltr", textAlign: "right" }
+      : undefined,
+    // Data attributes for CSS styling
+    "data-disabled": disabled ? "" : undefined,
+    "data-readonly": readOnly ? "" : undefined,
+    "data-required": required ? "" : undefined,
+  } as React.InputHTMLAttributes<HTMLInputElement>;
+
+  const hiddenInputProps: React.InputHTMLAttributes<HTMLInputElement> | null =
+    name
+      ? {
+          type: "hidden",
+          name,
+          value: state.numberValue ?? "",
+          "aria-hidden": true,
+        }
+      : null;
+
+  const incrementButtonProps: React.ButtonHTMLAttributes<HTMLButtonElement> = {
+    type: "button",
+    tabIndex: -1,
+    "aria-label": "Increase",
+    disabled: disabled || !state.canIncrement,
+    onClick: () => state.increment(),
+    "data-disabled": disabled || !state.canIncrement ? "" : undefined,
+  } as React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+  const decrementButtonProps: React.ButtonHTMLAttributes<HTMLButtonElement> = {
+    type: "button",
+    tabIndex: -1,
+    "aria-label": "Decrease",
+    disabled: disabled || !state.canDecrement,
+    onClick: () => state.decrement(),
+    "data-disabled": disabled || !state.canDecrement ? "" : undefined,
+  } as React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+  return {
+    labelProps,
+    groupProps,
+    inputProps,
+    hiddenInputProps,
+    incrementButtonProps,
+    decrementButtonProps,
+  };
+}

--- a/src/react/useNumberFieldState.test.ts
+++ b/src/react/useNumberFieldState.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useNumberFieldState } from "./useNumberFieldState.js";
+
+describe("useNumberFieldState", () => {
+  describe("initial value", () => {
+    it("starts with empty string and null for no defaultValue", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US" })
+      );
+      expect(result.current.inputValue).toBe("");
+      expect(result.current.numberValue).toBeNull();
+    });
+
+    it("formats defaultValue on mount", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US", defaultValue: 1234 })
+      );
+      expect(result.current.inputValue).toBe("1,234");
+      expect(result.current.numberValue).toBe(1234);
+    });
+
+    it("formats defaultValue with decimal", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US", defaultValue: 1234.56 })
+      );
+      expect(result.current.inputValue).toBe("1,234.56");
+    });
+  });
+
+  describe("setInputValue", () => {
+    it("parses and updates numberValue", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US" })
+      );
+      act(() => result.current.setInputValue("1,234"));
+      expect(result.current.numberValue).toBe(1234);
+      expect(result.current.inputValue).toBe("1,234");
+    });
+
+    it("sets numberValue to null for empty string", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US", defaultValue: 5 })
+      );
+      act(() => result.current.setInputValue(""));
+      expect(result.current.numberValue).toBeNull();
+    });
+
+    it("preserves intermediate state without reformatting", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US" })
+      );
+      act(() => result.current.setInputValue("1."));
+      expect(result.current.inputValue).toBe("1.");
+      expect(result.current.numberValue).toBeNull();
+    });
+
+    it("fires onChange when value changes", () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US", onChange })
+      );
+      act(() => result.current.setInputValue("42"));
+      expect(onChange).toHaveBeenCalledWith(42);
+    });
+  });
+
+  describe("setNumberValue", () => {
+    it("formats and sets both values", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US" })
+      );
+      act(() => result.current.setNumberValue(9999));
+      expect(result.current.numberValue).toBe(9999);
+      expect(result.current.inputValue).toBe("9,999");
+    });
+
+    it("clears both values when null", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US", defaultValue: 5 })
+      );
+      act(() => result.current.setNumberValue(null));
+      expect(result.current.numberValue).toBeNull();
+      expect(result.current.inputValue).toBe("");
+    });
+  });
+
+  describe("increment / decrement", () => {
+    it("increments by default step (1)", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US", defaultValue: 5 })
+      );
+      act(() => result.current.increment());
+      expect(result.current.numberValue).toBe(6);
+    });
+
+    it("decrements by default step (1)", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US", defaultValue: 5 })
+      );
+      act(() => result.current.decrement());
+      expect(result.current.numberValue).toBe(4);
+    });
+
+    it("increments by custom step", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US", defaultValue: 5, step: 5 })
+      );
+      act(() => result.current.increment());
+      expect(result.current.numberValue).toBe(10);
+    });
+
+    it("increments by custom amount", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US", defaultValue: 5 })
+      );
+      act(() => result.current.increment(10));
+      expect(result.current.numberValue).toBe(15);
+    });
+
+    it("clamps increment at maxValue", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US", defaultValue: 9, maxValue: 10 })
+      );
+      act(() => result.current.increment());
+      expect(result.current.numberValue).toBe(10);
+      act(() => result.current.increment());
+      expect(result.current.numberValue).toBe(10);
+    });
+
+    it("clamps decrement at minValue", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US", defaultValue: 1, minValue: 0 })
+      );
+      act(() => result.current.decrement());
+      expect(result.current.numberValue).toBe(0);
+      act(() => result.current.decrement());
+      expect(result.current.numberValue).toBe(0);
+    });
+
+    it("handles floating point steps precisely", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US", defaultValue: 0.1, step: 0.1 })
+      );
+      act(() => result.current.increment());
+      expect(result.current.numberValue).toBe(0.2);
+    });
+  });
+
+  describe("canIncrement / canDecrement", () => {
+    it("canIncrement is false at maxValue", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US", defaultValue: 10, maxValue: 10 })
+      );
+      expect(result.current.canIncrement).toBe(false);
+    });
+
+    it("canDecrement is false at minValue", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US", defaultValue: 0, minValue: 0 })
+      );
+      expect(result.current.canDecrement).toBe(false);
+    });
+
+    it("canIncrement is true below maxValue", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US", defaultValue: 5, maxValue: 10 })
+      );
+      expect(result.current.canIncrement).toBe(true);
+    });
+
+    it("canIncrement/canDecrement are false when disabled", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US", disabled: true })
+      );
+      expect(result.current.canIncrement).toBe(false);
+      expect(result.current.canDecrement).toBe(false);
+    });
+  });
+
+  describe("incrementToMax / decrementToMin", () => {
+    it("jumps to maxValue", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US", defaultValue: 5, maxValue: 100 })
+      );
+      act(() => result.current.incrementToMax());
+      expect(result.current.numberValue).toBe(100);
+    });
+
+    it("jumps to minValue", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US", defaultValue: 50, minValue: 0 })
+      );
+      act(() => result.current.decrementToMin());
+      expect(result.current.numberValue).toBe(0);
+    });
+  });
+
+  describe("commit (blur)", () => {
+    it("re-formats on commit", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({ locale: "en-US" })
+      );
+      act(() => result.current.setInputValue("1."));
+      expect(result.current.inputValue).toBe("1.");
+      act(() => result.current.commit());
+      // After commit, intermediate state is cleaned up
+      expect(result.current.inputValue).toBe("");
+    });
+
+    it("clamps to maxValue on blur when clampBehavior='blur'", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({
+          locale: "en-US",
+          maxValue: 100,
+          clampBehavior: "blur",
+        })
+      );
+      act(() => result.current.setInputValue("200"));
+      act(() => result.current.commit());
+      expect(result.current.numberValue).toBe(100);
+    });
+
+    it("does NOT clamp when clampBehavior='none'", () => {
+      const { result } = renderHook(() =>
+        useNumberFieldState({
+          locale: "en-US",
+          maxValue: 100,
+          clampBehavior: "none",
+        })
+      );
+      act(() => result.current.setInputValue("200"));
+      act(() => result.current.commit());
+      expect(result.current.numberValue).toBe(200);
+    });
+  });
+
+  describe("strict clamping", () => {
+    it("ignores input that exceeds maxValue", () => {
+      const onChange = vi.fn();
+      const { result } = renderHook(() =>
+        useNumberFieldState({
+          locale: "en-US",
+          maxValue: 100,
+          clampBehavior: "strict",
+          onChange,
+        })
+      );
+      act(() => result.current.setInputValue("200"));
+      // The value should not have changed
+      expect(result.current.numberValue).toBeNull();
+      expect(onChange).not.toHaveBeenCalledWith(200);
+    });
+  });
+});

--- a/src/react/useNumberFieldState.ts
+++ b/src/react/useNumberFieldState.ts
@@ -1,0 +1,262 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import type { NumberFieldState, UseNumberFieldStateOptions } from "../core/types.js";
+import { createFormatter } from "../core/formatter.js";
+import { createParser } from "../core/parser.js";
+import { useControllableState } from "./useControllableState.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function clamp(value: number, min?: number, max?: number): number {
+  let v = value;
+  if (min !== undefined) v = Math.max(v, min);
+  if (max !== undefined) v = Math.min(v, max);
+  return v;
+}
+
+function preciseAdd(a: number, b: number): number {
+  // Simple float precision fix — avoids 0.1 + 0.2 = 0.30000000000000004
+  const precision = Math.max(
+    decimalPlaces(a),
+    decimalPlaces(b)
+  );
+  const factor = 10 ** precision;
+  return Math.round(a * factor + b * factor) / factor;
+}
+
+function decimalPlaces(n: number): number {
+  const s = String(n);
+  const idx = s.indexOf(".");
+  return idx === -1 ? 0 : s.length - idx - 1;
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+export function useNumberFieldState(
+  options: UseNumberFieldStateOptions
+): NumberFieldState {
+  const {
+    locale,
+    formatOptions,
+    minValue,
+    maxValue,
+    step = 1,
+    largeStep,
+    smallStep,
+    allowNegative = true,
+    allowDecimal = true,
+    maximumFractionDigits,
+    minimumFractionDigits,
+    fixedDecimalScale,
+    clampBehavior = "blur",
+    prefix,
+    suffix,
+  } = options;
+
+  // ── Formatter & parser (re-created only when deps change) ──────────────────
+  const formatter = useMemo(
+    () =>
+      createFormatter({
+        locale,
+        formatOptions,
+        prefix,
+        suffix,
+        minimumFractionDigits,
+        maximumFractionDigits,
+        fixedDecimalScale,
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      locale,
+      // JSON-serialize to detect object identity changes
+      JSON.stringify(formatOptions),
+      prefix,
+      suffix,
+      minimumFractionDigits,
+      maximumFractionDigits,
+      fixedDecimalScale,
+    ]
+  );
+
+  const parser = useMemo(
+    () =>
+      createParser({
+        locale,
+        formatOptions,
+        allowNegative,
+        allowDecimal,
+        prefix,
+        suffix,
+      }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      locale,
+      JSON.stringify(formatOptions),
+      allowNegative,
+      allowDecimal,
+      prefix,
+      suffix,
+    ]
+  );
+
+  // ── Controlled/uncontrolled numeric value ──────────────────────────────────
+  const [numberValue, setNumberValue] = useControllableState<number | null>({
+    value: options.value,
+    defaultValue: options.defaultValue ?? null,
+    onChange: options.onChange,
+  });
+
+  // ── Display string ─────────────────────────────────────────────────────────
+  // Stored in local state — can transiently diverge from numberValue
+  // (e.g. while typing "1." which isn't a valid JS number yet)
+  const initialDisplay = useMemo(() => {
+    if (options.defaultValue != null) {
+      return formatter.format(options.defaultValue);
+    }
+    if (options.value != null) {
+      return formatter.format(options.value);
+    }
+    return "";
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Only on mount
+
+  const [inputValue, setInputValueRaw] = useState<string>(initialDisplay);
+
+  // Track last formatted value so we can sync controlled value changes
+  const lastFormattedRef = useRef<string>(initialDisplay);
+
+  // Sync controlled value → display string when value changes externally
+  // (not when the user is typing)
+  const externalValue = options.value;
+  const prevExternalValueRef = useRef(externalValue);
+  if (prevExternalValueRef.current !== externalValue) {
+    prevExternalValueRef.current = externalValue;
+    if (externalValue != null) {
+      const formatted = formatter.format(externalValue);
+      if (formatted !== lastFormattedRef.current) {
+        lastFormattedRef.current = formatted;
+        // Using a ref mutation here avoids an extra render cycle;
+        // React will flush this synchronously in the current render.
+        // We'll update display state in a useEffect-like pattern below.
+      }
+    } else {
+      lastFormattedRef.current = "";
+    }
+  }
+
+  // ── setInputValue ──────────────────────────────────────────────────────────
+  const setInputValue = useCallback(
+    (val: string) => {
+      const result = parser.parse(val);
+
+      // Strict clamping: reject input that goes out of range
+      if (clampBehavior === "strict" && result.value !== null) {
+        if (minValue !== undefined && result.value < minValue) return;
+        if (maxValue !== undefined && result.value > maxValue) return;
+      }
+
+      setInputValueRaw(val);
+      setNumberValue(result.value);
+    },
+    [parser, clampBehavior, minValue, maxValue, setNumberValue]
+  );
+
+  // ── setNumberValue (external) ──────────────────────────────────────────────
+  const setNumericValue = useCallback(
+    (val: number | null) => {
+      setNumberValue(val);
+      if (val != null) {
+        const formatted = formatter.format(val);
+        setInputValueRaw(formatted);
+        lastFormattedRef.current = formatted;
+      } else {
+        setInputValueRaw("");
+        lastFormattedRef.current = "";
+      }
+    },
+    [formatter, setNumberValue]
+  );
+
+  // ── commit (called on blur) ────────────────────────────────────────────────
+  const commit = useCallback(() => {
+    if (numberValue == null) {
+      setInputValueRaw("");
+      lastFormattedRef.current = "";
+      return;
+    }
+
+    let clamped = numberValue;
+    if (clampBehavior === "blur") {
+      clamped = clamp(numberValue, minValue, maxValue);
+    }
+
+    const formatted = formatter.format(clamped);
+    setInputValueRaw(formatted);
+    lastFormattedRef.current = formatted;
+
+    if (clamped !== numberValue) {
+      setNumberValue(clamped);
+    }
+  }, [numberValue, clampBehavior, minValue, maxValue, formatter, setNumberValue]);
+
+  // ── Step computation ───────────────────────────────────────────────────────
+  const resolvedLargeStep = largeStep ?? step * 10;
+  const resolvedSmallStep = smallStep ?? step * 0.1;
+
+  const canIncrement =
+    !options.disabled &&
+    !options.readOnly &&
+    (maxValue === undefined || (numberValue ?? -Infinity) < maxValue);
+
+  const canDecrement =
+    !options.disabled &&
+    !options.readOnly &&
+    (minValue === undefined || (numberValue ?? Infinity) > minValue);
+
+  const increment = useCallback(
+    (amount?: number) => {
+      const s = amount ?? step;
+      const base = numberValue ?? 0;
+      const next = clamp(preciseAdd(base, s), minValue, maxValue);
+      setNumericValue(next);
+    },
+    [numberValue, step, minValue, maxValue, setNumericValue]
+  );
+
+  const decrement = useCallback(
+    (amount?: number) => {
+      const s = amount ?? step;
+      const base = numberValue ?? 0;
+      const next = clamp(preciseAdd(base, -s), minValue, maxValue);
+      setNumericValue(next);
+    },
+    [numberValue, step, minValue, maxValue, setNumericValue]
+  );
+
+  const incrementToMax = useCallback(() => {
+    if (maxValue !== undefined) setNumericValue(maxValue);
+  }, [maxValue, setNumericValue]);
+
+  const decrementToMin = useCallback(() => {
+    if (minValue !== undefined) setNumericValue(minValue);
+  }, [minValue, setNumericValue]);
+
+  return {
+    inputValue,
+    numberValue: numberValue ?? null,
+    canIncrement,
+    canDecrement,
+    setInputValue,
+    setNumberValue: setNumericValue,
+    commit,
+    increment,
+    decrement,
+    incrementToMax,
+    decrementToMin,
+    options: {
+      ...options,
+      step,
+      largeStep: resolvedLargeStep,
+      smallStep: resolvedSmallStep,
+    },
+  };
+}

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "verbatimModuleSyntax": true,
+    "declaration": true,
+    "noEmit": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": false
+  },
+  "include": ["src"]
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig([
+  // Main entries: index, core, react
+  {
+    entry: {
+      index: "src/index.ts",
+      core: "src/core/index.ts",
+      react: "src/react/index.ts",
+    },
+    format: ["cjs", "esm"],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+    external: ["react", "react-dom"],
+    banner: { js: '"use client";' },
+    outExtension: ({ format }) => ({
+      js: format === "cjs" ? ".cjs" : ".js",
+    }),
+    treeshake: true,
+    splitting: false,
+    minify: true,
+  },
+  // Locale plugins — separate entries for tree-shaking
+  {
+    entry: {
+      "locales/fa": "src/locales/fa.ts",
+      "locales/ar": "src/locales/ar.ts",
+      "locales/bn": "src/locales/bn.ts",
+      "locales/hi": "src/locales/hi.ts",
+      "locales/th": "src/locales/th.ts",
+      "locales/index": "src/locales/index.ts",
+    },
+    format: ["cjs", "esm"],
+    dts: true,
+    sourcemap: true,
+    external: ["react", "react-dom"],
+    outExtension: ({ format }) => ({
+      js: format === "cjs" ? ".cjs" : ".js",
+    }),
+    treeshake: true,
+  },
+]);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test-setup.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
+    coverage: {
+      reporter: ["text", "json", "html"],
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: ["src/**/*.test.{ts,tsx}", "src/test-setup.ts"],
+    },
+  },
+});


### PR DESCRIPTION
Complete Phase 1 implementation of numra, a React number input library
that unifies live formatting, i18n digit support (Persian/Arabic/Bengali/
Hindi/Thai), true headless composability, and gold-standard accessibility.

Core engine (1.8 KB gzipped):
- formatter.ts: Intl.NumberFormat wrapper with caching, locale info extraction
  via formatToParts() — no hardcoded separators
- parser.ts: locale-aware parsing with intermediate state detection ("-", "1.")
- cursor.ts: 3-stage accepted-chars boundary algorithm for cursor preservation
- normalizer.ts: Unicode digit normalization with extensible locale registry

React layer (4.3 KB gzipped):
- useNumberFieldState: pure state hook with clamping, stepping, controlled state
- useNumberField: behavior hook wiring cursor engine, ARIA, keyboard, wheel
- NumberField: compound headless components (Root/Label/Group/Input/Increment/
  Decrement/HiddenInput) with render prop pattern and data attributes

Locale plugins (~101 bytes each): fa, ar, bn, hi, th

124 tests passing across 6 suites. All DEFINITION.md Priority 1 features
implemented. Bundle targets met: core < 2 KB, full < 5 KB.

https://claude.ai/code/session_01HzywWR6r5L3Urq1YUhZ2f8