### PR TITLE
Fix release workflow permissions and docs link

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,10 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     name: Release

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ hero:
   tagline: Live formatting • Full i18n • Headless • Accessible • < 5 KB
   actions:
     - text: Get Started
-      link: /getting-started
+      link: getting-started
       icon: right-arrow
       variant: primary
     - text: View on GitHub


### PR DESCRIPTION
## Summary

This PR makes two small but important fixes:

1. **Release workflow permissions**: Adds explicit `contents: write` and `pull-requests: write` permissions to the release workflow. This ensures the workflow has the necessary permissions to create releases and manage pull requests without relying on default token permissions.

2. **Documentation link fix**: Corrects the "Get Started" link in the homepage from an absolute path (`/getting-started`) to a relative path (`getting-started`). This ensures proper navigation within the documentation site.

## Checklist

- [x] No tests needed for configuration and documentation updates
- [x] Changes are minimal and non-breaking
- [x] No user-facing API changes requiring a changeset

## Related issues

None

https://claude.ai/code/session_01UBqYDQAdSyMkZQQjjyTrzW