### PR TITLE
fix(release): add id-token write permission for npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

- Add `id-token: write` permission to the release workflow

## Problem

Publishing `numra@0.2.0` failed with:

```
EUSAGE Provenance generation in GitHub Actions requires "write" access to the "id-token" permission
```

The workflow had `contents: write` and `pull-requests: write` but was missing `id-token: write`, which npm requires when `publishConfig.provenance: true` is set.

## Fix

```yaml
permissions:
  contents: write
  pull-requests: write
  id-token: write   # ← added
```

## After merge

The release workflow will re-trigger on push to main, detect that `numra@0.2.0` is unpublished, and publish it to npm with provenance attestation.

https://claude.ai/code/session_01Uyd9F2JvGwEPU69DT9mc3y