### PR TITLE
feat: rebrand package from numra to raqam (رقم)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -10,7 +10,7 @@ body:
   - type: input
     id: version
     attributes:
-      label: numra version
+      label: raqam version
       placeholder: e.g. 0.1.0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: Problem / Motivation
       description: What problem does this solve? What use case is not covered today?
-      placeholder: "When I use numra for a financial app, I can't do X because..."
+      placeholder: "When I use raqam for a financial app, I can't do X because..."
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/locale.yml
+++ b/.github/ISSUE_TEMPLATE/locale.yml
@@ -5,9 +5,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        numra supports locale-aware formatting via `Intl.NumberFormat` for all CLDR locales.
+        raqam supports locale-aware formatting via `Intl.NumberFormat` for all CLDR locales.
         This template is for requesting a **digit-normalization plugin** for a non-Latin script
-        (similar to the existing `numra/locales/fa`, `numra/locales/ar`, etc.).
+        (similar to the existing `raqam/locales/fa`, `raqam/locales/ar`, etc.).
 
   - type: input
     id: bcp47

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,8 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm changeset publish
-          title: "chore: release numra"
-          commit: "chore: release numra"
+          title: "chore: release raqam"
+          commit: "chore: release raqam"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,21 +1,21 @@
 [
   {
-    "name": "numra/core",
+    "name": "raqam/core",
     "path": "dist/core.js",
     "limit": "2 KB"
   },
   {
-    "name": "numra (full)",
+    "name": "raqam (full)",
     "path": "dist/index.js",
     "limit": "12 KB"
   },
   {
-    "name": "numra/react",
+    "name": "raqam/react",
     "path": "dist/react.js",
     "limit": "10 KB"
   },
   {
-    "name": "numra/locales/fa",
+    "name": "raqam/locales/fa",
     "path": "dist/locales/fa.js",
     "limit": "0.3 KB"
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# numra Changelog
+# raqam Changelog
 
 ## 0.2.0
 
@@ -6,7 +6,7 @@
 
 - d1c28e3: Phase 5 — Polish and release:
 
-  - **Bundle optimization**: `numra/core` reduced to < 2 KB gzipped; removed `isNonLatinDigit` from core exports (still available via direct `numra/core/normalizer` import in tests); split tsup config so `numra/core` (the server-safe entry) does not receive a `"use client"` banner
+  - **Bundle optimization**: `raqam/core` reduced to < 2 KB gzipped; removed `isNonLatinDigit` from core exports (still available via direct `raqam/core/normalizer` import in tests); split tsup config so `raqam/core` (the server-safe entry) does not receive a `"use client"` banner
   - **`"use client"` directive**: Fixed — now correctly prepended to `dist/index.js`, `dist/index.cjs`, `dist/react.js`, `dist/react.cjs` via post-build step (esbuild 0.25+ strips source-level directives from bundled output)
   - **Storybook**: Added `preview.ts` with `layout: "centered"`, table-of-contents, and control matchers; new `HookAPI.stories.tsx` demonstrating `useNumberFieldState` + `useNumberField` hook pair directly
   - **react-hook-form integration**: Upgraded `Validation.stories.tsx` to use real `react-hook-form` `Controller` pattern (was previously simulated); added `react-hook-form` as devDependency
@@ -17,9 +17,9 @@
 
 ### New package
 
-**numra** — the definitive React number input with live formatting, full i18n, headless architecture, and WAI-ARIA accessibility.
+**raqam** — the definitive React number input with live formatting, full i18n, headless architecture, and WAI-ARIA accessibility.
 
-#### Core engine (`numra/core`, `numra/server`)
+#### Core engine (`raqam/core`, `raqam/server`)
 
 - **Live formatting** with cursor preservation via the accepted-characters boundary algorithm
 - `createFormatter` — `Intl.NumberFormat` wrapper with caching and locale info extraction
@@ -29,7 +29,7 @@
 - `registerLocale` — plugin API for custom digit blocks
 - `presets` — named `Intl.NumberFormatOptions` for currency, accounting, percent, compact, scientific, engineering, integer, financial, unit
 
-#### React hooks (`numra/react`)
+#### React hooks (`raqam/react`)
 
 - `useNumberFieldState` — state management (controlled/uncontrolled, formatting, clamping, validation, scrubbing, focus)
 - `useNumberField` — behavior hook (ARIA spinbutton, keyboard, wheel, paste, copy, IME, cursor)
@@ -38,7 +38,7 @@
 - `usePressAndHold` — press-and-hold acceleration for stepper buttons
 - `useScrubArea` — Pointer Lock API drag-to-adjust
 
-#### Headless components (`numra`)
+#### Headless components (`raqam`)
 
 - `NumberField.Root` — context provider with full state wiring
 - `NumberField.Input` — ARIA spinbutton text input with live formatting
@@ -53,11 +53,11 @@
 
 #### Locale plugins (tree-shakeable, ~100 B each)
 
-- `numra/locales/fa` — Persian / Extended Arabic-Indic digits (۰–۹)
-- `numra/locales/ar` — Arabic-Indic digits (٠–٩)
-- `numra/locales/hi` — Devanagari digits (०–९), supports lakh/crore grouping
-- `numra/locales/bn` — Bengali digits (০–৯)
-- `numra/locales/th` — Thai digits (๐–๙)
+- `raqam/locales/fa` — Persian / Extended Arabic-Indic digits (۰–۹)
+- `raqam/locales/ar` — Arabic-Indic digits (٠–٩)
+- `raqam/locales/hi` — Devanagari digits (०–९), supports lakh/crore grouping
+- `raqam/locales/bn` — Bengali digits (০–৯)
+- `raqam/locales/th` — Thai digits (๐–๙)
 
 #### Features
 
@@ -74,17 +74,17 @@
 - **Raw value** — `onRawChange` for arbitrary-precision financial use cases
 - **`data-*` attributes** — `data-focused`, `data-invalid`, `data-disabled`, `data-readonly`, `data-rtl` for CSS styling
 - **`render` prop** — element replacement without `asChild` peer dependency
-- **Server Component compatible** — `numra/server` (= `numra/core`) has zero React dependency
+- **Server Component compatible** — `raqam/server` (= `raqam/core`) has zero React dependency
 - **`"use client"` directive** — prepended to client bundles for Next.js App Router
 
 #### Bundle sizes
 
 | Entry              | Gzipped  |
 | ------------------ | -------- |
-| `numra/core`       | < 2 KB   |
-| `numra`            | < 9 KB   |
-| `numra/react`      | < 8 KB   |
-| `numra/locales/fa` | < 0.3 KB |
+| `raqam/core`       | < 2 KB   |
+| `raqam`            | < 9 KB   |
+| `raqam/react`      | < 8 KB   |
+| `raqam/locales/fa` | < 0.3 KB |
 
 #### Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
-# Contributing to numra
+# Contributing to raqam
 
 ## Development setup
 
 ```bash
 # Clone and install
 git clone https://github.com/47vigen/numra.git
-cd numra
+cd raqam
 pnpm install
 
 # Run tests in watch mode

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# numra 🔢
+# raqam 🔢
 
 **The definitive React number input: live formatting, full i18n, headless, accessible.**
 
-[![npm version](https://img.shields.io/npm/v/numra)](https://www.npmjs.com/package/numra)
-[![bundle size](https://img.shields.io/bundlephobia/minzip/numra)](https://bundlephobia.com/package/numra)
+[![npm version](https://img.shields.io/npm/v/raqam)](https://www.npmjs.com/package/raqam)
+[![bundle size](https://img.shields.io/bundlephobia/minzip/raqam)](https://bundlephobia.com/package/raqam)
 [![CI](https://img.shields.io/github/actions/workflow/status/47vigen/numra/ci.yml?label=CI)](https://github.com/47vigen/numra/actions)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](https://www.typescriptlang.org/)
-[![license](https://img.shields.io/npm/l/numra)](LICENSE)
+[![license](https://img.shields.io/npm/l/raqam)](LICENSE)
 
-## ✨ Why numra?
+## ✨ Why raqam?
 
-| Feature | Base UI | React Aria | Mantine | **numra** |
+| Feature | Base UI | React Aria | Mantine | **raqam** |
 |---------|:-------:|:----------:|:-------:|:---------:|
 | Live formatting while typing | ❌ blur | ❌ blur | ✅ | ✅ |
 | Truly headless | ✅ | ✅ | ❌ | ✅ |
@@ -18,14 +18,14 @@
 | WAI-ARIA spinbutton | ✅ | ✅✅ | ⚠️ | ✅✅ |
 | Bundle size | ~10 KB | ~30 KB | ~60 KB | **~1.7 KB core** |
 
-No existing package combines all four. numra does.
+No existing package combines all four. raqam does.
 
 ## 📦 Installation
 
 ```bash
-npm install numra
+npm install raqam
 # or
-pnpm add numra
+pnpm add raqam
 ```
 
 **Peer dependencies:** React 18 or 19.
@@ -35,7 +35,7 @@ pnpm add numra
 ### Hook API
 
 ```tsx
-import { useNumberFieldState, useNumberField } from 'numra'
+import { useNumberFieldState, useNumberField } from 'raqam'
 import { useRef } from 'react'
 
 function PriceInput() {
@@ -63,7 +63,7 @@ function PriceInput() {
 ### Headless Component API
 
 ```tsx
-import { NumberField } from 'numra'
+import { NumberField } from 'raqam'
 
 function PriceField() {
   return (
@@ -90,7 +90,7 @@ function PriceField() {
 ## 🎨 Format presets
 
 ```tsx
-import { presets, NumberField } from 'numra'
+import { presets, NumberField } from 'raqam'
 
 <NumberField.Root formatOptions={presets.currency('USD')} />           // $1,234.56
 <NumberField.Root formatOptions={presets.accounting('USD')} />         // (1,234.56)
@@ -107,15 +107,15 @@ import { presets, NumberField } from 'numra'
 Persian input with native digits — just import the plugin and set the locale:
 
 ```tsx
-import 'numra/locales/fa'  // registers ۰–۹ digit normalization (< 200 B)
-import { NumberField } from 'numra'
+import 'raqam/locales/fa'  // registers ۰–۹ digit normalization (< 200 B)
+import { NumberField } from 'raqam'
 
 <NumberField.Root
   locale="fa-IR"
   formatOptions={{ style: 'currency', currency: 'IRR' }}
   suffix=" تومان"
 />
-// user types ۱۲۳۴, numra parses and formats it correctly in real-time
+// user types ۱۲۳۴, raqam parses and formats it correctly in real-time
 ```
 
 Supported scripts: 🇮🇷 Persian `fa`, 🇸🇦 Arabic `ar`, 🇧🇩 Bengali `bn`, 🇮🇳 Hindi `hi`, 🇹🇭 Thai `th`. RTL is auto-detected and handled.
@@ -139,7 +139,7 @@ Supported scripts: 🇮🇷 Persian `fa`, 🇸🇦 Arabic `ar`, 🇧🇩 Bengali
 ## 👁️ Display-only formatting
 
 ```tsx
-import { useNumberFieldFormat } from 'numra'
+import { useNumberFieldFormat } from 'raqam'
 
 function PriceDisplay({ price }: { price: number }) {
   const formatted = useNumberFieldFormat(price, {
@@ -150,10 +150,10 @@ function PriceDisplay({ price }: { price: number }) {
 }
 ```
 
-Works in React Server Components too via `numra/server`:
+Works in React Server Components too via `raqam/server`:
 
 ```tsx
-import { createFormatter } from 'numra/server'  // zero React deps
+import { createFormatter } from 'raqam/server'  // zero React deps
 
 const formatter = createFormatter({
   locale: 'en-US',
@@ -192,7 +192,7 @@ Uses the Pointer Lock API so the cursor never hits the screen edge during drag.
 
 ```tsx
 import { Controller } from 'react-hook-form'
-import { NumberField } from 'numra'
+import { NumberField } from 'raqam'
 
 <Controller
   name="price"
@@ -299,7 +299,7 @@ Additional props beyond state options:
 
 ### `useNumberFieldFormat(value, options)`
 
-Display-only formatting hook. Returns a formatted string. Zero state overhead — safe in RSC via `numra/server`.
+Display-only formatting hook. Returns a formatted string. Zero state overhead — safe in RSC via `raqam/server`.
 
 ### `NumberField.*` components
 
@@ -334,10 +334,10 @@ Actual sizes (brotli compressed):
 
 | Entry | Size |
 |-------|------|
-| `numra/core` | ~1.7 KB |
-| `numra` (hooks + components) | ~7 KB |
-| `numra/react` | ~6.8 KB |
-| `numra/locales/fa` | ~200 B |
+| `raqam/core` | ~1.7 KB |
+| `raqam` (hooks + components) | ~7 KB |
+| `raqam/react` | ~6.8 KB |
+| `raqam/locales/fa` | ~200 B |
 
 ## 📄 License
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -6,7 +6,7 @@ export default defineConfig({
   base: "/numra",
   integrations: [
     starlight({
-      title: "numra",
+      title: "raqam",
       description:
         "The definitive React number input: live formatting, full i18n, headless, accessible",
       social: [

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "numra-docs",
+  "name": "raqam-docs",
   "version": "0.0.1",
   "private": true,
   "type": "module",

--- a/docs/src/content/docs/api/components.mdx
+++ b/docs/src/content/docs/api/components.mdx
@@ -11,7 +11,7 @@ wiring internally via React Context. No prop drilling, no `ref` management.
 ## Import
 
 ```ts
-import { NumberField } from "numra";
+import { NumberField } from "raqam";
 ```
 
 ## Component tree

--- a/docs/src/content/docs/api/presets.mdx
+++ b/docs/src/content/docs/api/presets.mdx
@@ -9,15 +9,15 @@ most common number formatting patterns. Pass them directly as `formatOptions`.
 ## Import
 
 ```ts
-import { presets } from "numra";
+import { presets } from "raqam";
 // or
-import { presets } from "numra/core";
+import { presets } from "raqam/core";
 ```
 
 ## Usage
 
 ```tsx
-import { presets } from "numra";
+import { presets } from "raqam";
 
 <NumberField.Root formatOptions={presets.currency("USD")} locale="en-US" />
 <NumberField.Root formatOptions={presets.percent} locale="en-US" />
@@ -52,7 +52,7 @@ presets.accounting("USD")
 ```
 
 Like `currency` but shows negative values in parentheses: `(1,234.56)`.
-numra automatically parses `(...)` back to a negative number.
+raqam automatically parses `(...)` back to a negative number.
 
 ---
 

--- a/docs/src/content/docs/api/use-number-field-format.mdx
+++ b/docs/src/content/docs/api/use-number-field-format.mdx
@@ -10,9 +10,9 @@ read-only numeric display.
 ## Import
 
 ```ts
-import { useNumberFieldFormat } from "numra";
+import { useNumberFieldFormat } from "raqam";
 // or
-import { useNumberFieldFormat } from "numra/react";
+import { useNumberFieldFormat } from "raqam/react";
 ```
 
 ## Signature
@@ -42,7 +42,7 @@ A formatted string, or `""` when `value` is null/undefined/NaN.
 ## Example — price table
 
 ```tsx
-import { useNumberFieldFormat } from "numra";
+import { useNumberFieldFormat } from "raqam";
 
 function PriceTag({ amount }: { amount: number }) {
   const formatted = useNumberFieldFormat(amount, {
@@ -60,10 +60,10 @@ function PriceTag({ amount }: { amount: number }) {
 
 ## Example — server-side use
 
-For React Server Components or SSR, import from `numra/server` (zero React dependency):
+For React Server Components or SSR, import from `raqam/server` (zero React dependency):
 
 ```ts
-import { createFormatter } from "numra/server";
+import { createFormatter } from "raqam/server";
 
 const formatter = createFormatter({
   locale: "en-US",

--- a/docs/src/content/docs/api/use-number-field-state.mdx
+++ b/docs/src/content/docs/api/use-number-field-state.mdx
@@ -14,9 +14,9 @@ for your elements.
 ## Import
 
 ```ts
-import { useNumberFieldState } from "numra";
+import { useNumberFieldState } from "raqam";
 // or
-import { useNumberFieldState } from "numra/react";
+import { useNumberFieldState } from "raqam/react";
 ```
 
 ## Signature
@@ -114,7 +114,7 @@ function useNumberFieldState(
 
 ```tsx
 import { useRef } from "react";
-import { useNumberFieldState, useNumberField } from "numra";
+import { useNumberFieldState, useNumberField } from "raqam";
 
 function MyInput() {
   const ref = useRef<HTMLInputElement>(null);

--- a/docs/src/content/docs/api/use-number-field.mdx
+++ b/docs/src/content/docs/api/use-number-field.mdx
@@ -10,9 +10,9 @@ elements.
 ## Import
 
 ```ts
-import { useNumberField } from "numra";
+import { useNumberField } from "raqam";
 // or
-import { useNumberField } from "numra/react";
+import { useNumberField } from "raqam/react";
 ```
 
 ## Signature
@@ -87,7 +87,7 @@ passive-by-default `onWheel`) so `preventDefault()` can stop page scroll.
 
 ```tsx
 import { useRef } from "react";
-import { useNumberFieldState, useNumberField } from "numra";
+import { useNumberFieldState, useNumberField } from "raqam";
 
 function SpinnerInput({ label }: { label: string }) {
   const ref = useRef<HTMLInputElement>(null);

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: Install numra and build your first number field in under five minutes.
+description: Install raqam and build your first number field in under five minutes.
 ---
 
 import { Tabs, TabItem, Aside } from "@astrojs/starlight/components";
@@ -10,17 +10,17 @@ import { Tabs, TabItem, Aside } from "@astrojs/starlight/components";
 <Tabs>
   <TabItem label="npm">
     ```sh
-    npm install numra
+    npm install raqam
     ```
   </TabItem>
   <TabItem label="pnpm">
     ```sh
-    pnpm add numra
+    pnpm add raqam
     ```
   </TabItem>
   <TabItem label="yarn">
     ```sh
-    yarn add numra
+    yarn add raqam
     ```
   </TabItem>
 </Tabs>
@@ -32,7 +32,7 @@ import { Tabs, TabItem, Aside } from "@astrojs/starlight/components";
 ### Component API (recommended)
 
 ```tsx
-import { NumberField } from "numra";
+import { NumberField } from "raqam";
 
 export function QuantityInput() {
   return (
@@ -52,7 +52,7 @@ export function QuantityInput() {
 
 ```tsx
 import { useRef } from "react";
-import { useNumberFieldState, useNumberField } from "numra";
+import { useNumberFieldState, useNumberField } from "raqam";
 
 export function QuantityInput() {
   const inputRef = useRef<HTMLInputElement>(null);
@@ -81,7 +81,7 @@ export function QuantityInput() {
 
 ## Controlled vs uncontrolled
 
-Like all React form controls, numra supports both patterns.
+Like all React form controls, raqam supports both patterns.
 
 ### Uncontrolled (defaultValue)
 
@@ -169,7 +169,7 @@ For library-managed forms see [react-hook-form](/recipes/react-hook-form) and
 
 ## TypeScript
 
-numra is written in TypeScript. Key types:
+raqam is written in TypeScript. Key types:
 
 ```ts
 import type {
@@ -178,10 +178,10 @@ import type {
   UseNumberFieldProps,
   NumberFieldAria,
   ChangeReason,
-} from "numra";
+} from "raqam";
 ```
 
 <Aside type="tip">
-  Use `numra/core` for server-side formatting (RSC, edge functions). It has zero
+  Use `raqam/core` for server-side formatting (RSC, edge functions). It has zero
   React dependency. See [Next.js guide](/guides/nextjs).
 </Aside>

--- a/docs/src/content/docs/guides/accessibility.mdx
+++ b/docs/src/content/docs/guides/accessibility.mdx
@@ -3,7 +3,7 @@ title: Accessibility
 description: WAI-ARIA spinbutton role, keyboard navigation, and screen reader behaviour.
 ---
 
-numra implements the WAI-ARIA
+raqam implements the WAI-ARIA
 [`spinbutton`](https://www.w3.org/WAI/ARIA/apg/patterns/spinbutton/) pattern.
 All ARIA attributes are generated automatically — you don't need to add them
 manually.
@@ -109,12 +109,12 @@ announce the message immediately when it appears.
 
 ## Automated testing
 
-numra is tested with `jest-axe` for WCAG compliance:
+raqam is tested with `jest-axe` for WCAG compliance:
 
 ```ts
 import { axe, toHaveNoViolations } from "jest-axe";
 import { render } from "@testing-library/react";
-import { NumberField } from "numra";
+import { NumberField } from "raqam";
 
 expect.extend(toHaveNoViolations);
 

--- a/docs/src/content/docs/guides/locales.mdx
+++ b/docs/src/content/docs/guides/locales.mdx
@@ -1,11 +1,11 @@
 ---
 title: Locales & i18n
-description: Using numra with non-Latin digit systems — Persian, Arabic, Bengali, Hindi, Thai.
+description: Using raqam with non-Latin digit systems — Persian, Arabic, Bengali, Hindi, Thai.
 ---
 
 import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
-numra uses `Intl.NumberFormat` for all formatting and parsing. You never
+raqam uses `Intl.NumberFormat` for all formatting and parsing. You never
 hardcode separators — they're extracted dynamically from the browser's
 internationalization engine.
 
@@ -33,11 +33,11 @@ Five locale plugins add support for writing systems that use non-ASCII digits:
 
 | Plugin | Script | Digits | BCP 47 tags |
 |--------|--------|--------|-------------|
-| `numra/locales/fa` | Persian (Extended Arabic-Indic) | ۰۱۲۳۴۵۶۷۸۹ | `fa`, `fa-IR`, `fa-AF` |
-| `numra/locales/ar` | Arabic-Indic | ٠١٢٣٤٥٦٧٨٩ | `ar`, `ar-EG`, `ar-SA`, … |
-| `numra/locales/hi` | Devanagari | ०१२३४५६७८९ | `hi`, `hi-IN`, `mr`, `ne` |
-| `numra/locales/bn` | Bengali | ০১২৩৪৫৬৭৮৯ | `bn`, `bn-BD`, `bn-IN` |
-| `numra/locales/th` | Thai | ๐๑๒๓๔๕๖๗๘๙ | `th`, `th-TH` |
+| `raqam/locales/fa` | Persian (Extended Arabic-Indic) | ۰۱۲۳۴۵۶۷۸۹ | `fa`, `fa-IR`, `fa-AF` |
+| `raqam/locales/ar` | Arabic-Indic | ٠١٢٣٤٥٦٧٨٩ | `ar`, `ar-EG`, `ar-SA`, … |
+| `raqam/locales/hi` | Devanagari | ०१२३४५६७८९ | `hi`, `hi-IN`, `mr`, `ne` |
+| `raqam/locales/bn` | Bengali | ০১২৩৪৫৬৭৮৯ | `bn`, `bn-BD`, `bn-IN` |
+| `raqam/locales/th` | Thai | ๐๑๒๓๔๕๖๗๘๙ | `th`, `th-TH` |
 
 ### Installing a plugin
 
@@ -45,8 +45,8 @@ Import the locale plugin once, anywhere in your app (it runs as a side effect):
 
 ```ts
 // app/layout.tsx  or  src/main.tsx
-import "numra/locales/fa";   // adds Persian digit support
-import "numra/locales/ar";   // adds Arabic-Indic digit support
+import "raqam/locales/fa";   // adds Persian digit support
+import "raqam/locales/ar";   // adds Arabic-Indic digit support
 ```
 
 Then use the locale normally:
@@ -61,7 +61,7 @@ the plugin, `۱۲۳` is accepted and internally treated as `123`.
 ### All plugins at once
 
 ```ts
-import "numra/locales";   // imports fa, ar, hi, bn, th
+import "raqam/locales";   // imports fa, ar, hi, bn, th
 ```
 
 Each plugin is only ~100 bytes gzipped.
@@ -76,11 +76,11 @@ en-US:  10,000,000  (millions)
 hi-IN:  1,00,00,000 (crores)
 ```
 
-numra handles this automatically via `Intl.NumberFormat`.
+raqam handles this automatically via `Intl.NumberFormat`.
 
 ## RTL locales
 
-Arabic, Persian, Hebrew, and Urdu are right-to-left. numra automatically
+Arabic, Persian, Hebrew, and Urdu are right-to-left. raqam automatically
 detects RTL locales and applies the correct rendering. See the
 [RTL guide](/guides/rtl) for details.
 
@@ -89,7 +89,7 @@ detects RTL locales and applies the correct rendering. See the
 If you need a digit system not covered by the built-in plugins, register it:
 
 ```ts
-import { registerLocale } from "numra/core";
+import { registerLocale } from "raqam/core";
 
 // Mongolian digits: ᠐᠑᠒᠓᠔᠕᠖᠗᠘᠙ (U+1810–U+1819)
 registerLocale({

--- a/docs/src/content/docs/guides/nextjs.mdx
+++ b/docs/src/content/docs/guides/nextjs.mdx
@@ -1,20 +1,20 @@
 ---
 title: Next.js App Router
-description: Using numra with Next.js App Router — client components, Server Components, and edge functions.
+description: Using raqam with Next.js App Router — client components, Server Components, and edge functions.
 ---
 
 import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
 ## Client components
 
-numra is a client-side library (it uses React hooks, DOM APIs, and browser
+raqam is a client-side library (it uses React hooks, DOM APIs, and browser
 `Intl`). All components and hooks must run in a Client Component.
 
 ```tsx
 // components/price-input.tsx
 "use client";
 
-import { NumberField } from "numra";
+import { NumberField } from "raqam";
 
 export function PriceInput({ value, onChange }: {
   value: number | null;
@@ -39,20 +39,20 @@ export function PriceInput({ value, onChange }: {
 ```
 
 <Aside>
-  The `numra` package ships with `"use client";` prepended to its bundles.
+  The `raqam` package ships with `"use client";` prepended to its bundles.
   You can import it directly in Client Components without any extra wrapper.
 </Aside>
 
 ## Server Components — formatting only
 
 For SSR formatting (price display, report generation, email templates), import
-from `numra/server` — it has **zero React dependency** and runs in any
+from `raqam/server` — it has **zero React dependency** and runs in any
 server context including Edge Runtime:
 
 ```ts
 // app/products/page.tsx  (Server Component)
-import { createFormatter } from "numra/server";
-import { presets } from "numra/server";
+import { createFormatter } from "raqam/server";
+import { presets } from "raqam/server";
 
 const fmt = createFormatter({
   locale: "en-US",
@@ -66,7 +66,7 @@ export default function ProductsPage() {
 }
 ```
 
-`numra/server` is an alias for `numra/core`. It exports `createFormatter`,
+`raqam/server` is an alias for `raqam/core`. It exports `createFormatter`,
 `createParser`, `normalizeDigits`, `registerLocale`, and `presets`.
 
 ## Pattern: Server Component + Client Input
@@ -77,7 +77,7 @@ field.
 
 ```tsx
 // app/checkout/page.tsx  (Server Component)
-import { createFormatter } from "numra/server";
+import { createFormatter } from "raqam/server";
 import { CheckoutForm } from "./checkout-form";
 
 export default async function CheckoutPage() {
@@ -102,7 +102,7 @@ export default async function CheckoutPage() {
 "use client";
 
 import { useState } from "react";
-import { NumberField } from "numra";
+import { NumberField } from "raqam";
 
 export function CheckoutForm({
   productName,
@@ -141,8 +141,8 @@ for side-effect-only modules):
 
 ```tsx
 // app/layout.tsx
-import "numra/locales/fa";
-import "numra/locales/ar";
+import "raqam/locales/fa";
+import "raqam/locales/ar";
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return <html><body>{children}</body></html>;
@@ -156,13 +156,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
 ## Edge Runtime
 
-`numra/server` (`numra/core`) is Edge Runtime compatible — it uses only
+`raqam/server` (`raqam/core`) is Edge Runtime compatible — it uses only
 `Intl.NumberFormat` which is available in all modern edge environments
 (Vercel Edge, Cloudflare Workers, Deno Deploy).
 
 ```ts
 // edge-function.ts
-import { createFormatter } from "numra/server";
+import { createFormatter } from "raqam/server";
 
 export const runtime = "edge";
 

--- a/docs/src/content/docs/guides/rtl.mdx
+++ b/docs/src/content/docs/guides/rtl.mdx
@@ -1,6 +1,6 @@
 ---
 title: RTL Support
-description: How numra renders right-to-left number inputs for Arabic, Persian, Hebrew, and Urdu.
+description: How raqam renders right-to-left number inputs for Arabic, Persian, Hebrew, and Urdu.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -9,11 +9,11 @@ RTL (right-to-left) number inputs have a subtle rendering challenge: the
 **numbers themselves are always left-to-right** (digits flow 0→9 regardless of
 script), but the **surrounding text and layout** flows right-to-left.
 
-numra handles this automatically for all RTL locales.
+raqam handles this automatically for all RTL locales.
 
 ## Auto-detection
 
-numra detects RTL locales via `Intl.NumberFormat.resolvedOptions().locale`:
+raqam detects RTL locales via `Intl.NumberFormat.resolvedOptions().locale`:
 
 ```ts
 // Detected as RTL:
@@ -28,7 +28,7 @@ correct styles are applied automatically.
 
 ## What gets applied
 
-For RTL locales, numra applies two CSS properties to the input element:
+For RTL locales, raqam applies two CSS properties to the input element:
 
 ```css
 direction: ltr;       /* numbers flow left-to-right */
@@ -56,8 +56,8 @@ input[data-rtl] {
 ## Persian example
 
 ```tsx
-import "numra/locales/fa";
-import { NumberField } from "numra";
+import "raqam/locales/fa";
+import { NumberField } from "raqam";
 
 <NumberField.Root
   locale="fa-IR"
@@ -79,8 +79,8 @@ normalizing them to the same value internally.
 ## Arabic example
 
 ```tsx
-import "numra/locales/ar";
-import { NumberField } from "numra";
+import "raqam/locales/ar";
+import { NumberField } from "raqam";
 
 <NumberField.Root
   locale="ar-EG"
@@ -100,7 +100,7 @@ container with `dir="rtl"`:
 
 ```html
 <div dir="rtl">
-  <!-- numra handles the input direction internally -->
+  <!-- raqam handles the input direction internally -->
   <NumberField.Root locale="fa-IR" ...>
     ...
   </NumberField.Root>
@@ -108,7 +108,7 @@ container with `dir="rtl"`:
 ```
 
 <Aside type="caution">
-  Don't set `dir="rtl"` on the `<input>` element itself — numra manages
+  Don't set `dir="rtl"` on the `<input>` element itself — raqam manages
   `direction: ltr` on the input to keep digit order correct.
 </Aside>
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: numra
+title: raqam
 description: The definitive React number input — live formatting, full i18n, headless, accessible
 template: splash
 hero:
@@ -16,9 +16,9 @@ hero:
 
 import { Card, CardGrid } from "@astrojs/starlight/components";
 
-## Why numra?
+## Why raqam?
 
-Every other React number input forces a trade-off. **numra eliminates all four.**
+Every other React number input forces a trade-off. **raqam eliminates all four.**
 
 <CardGrid>
   <Card title="Live formatting" icon="pencil">
@@ -42,17 +42,17 @@ Every other React number input forces a trade-off. **numra eliminates all four.*
 ## Quick install
 
 ```sh
-npm install numra
+npm install raqam
 # or
-pnpm add numra
+pnpm add raqam
 # or
-yarn add numra
+yarn add raqam
 ```
 
 ## Thirty-second example
 
 ```tsx
-import { NumberField } from "numra";
+import { NumberField } from "raqam";
 
 export function PriceInput() {
   return (
@@ -80,7 +80,7 @@ Type `1234` → see `$1,234.00`. Type `1234.5` → see `$1,234.5` (live, no flic
 
 | Import | Gzipped |
 |--------|---------|
-| `numra/core` | < 2 KB |
-| `numra` (full) | < 9 KB |
-| `numra/locales/fa` | < 0.3 KB |
-| `numra/locales/ar` | < 0.3 KB |
+| `raqam/core` | < 2 KB |
+| `raqam` (full) | < 9 KB |
+| `raqam/locales/fa` | < 0.3 KB |
+| `raqam/locales/ar` | < 0.3 KB |

--- a/docs/src/content/docs/recipes/financial.mdx
+++ b/docs/src/content/docs/recipes/financial.mdx
@@ -9,8 +9,8 @@ Show negative balances as `(1,234.56)` instead of `-$1,234.56` — standard in
 double-entry bookkeeping:
 
 ```tsx
-import { presets } from "numra";
-import { NumberField } from "numra";
+import { presets } from "raqam";
+import { NumberField } from "raqam";
 
 <NumberField.Root
   locale="en-US"
@@ -25,7 +25,7 @@ import { NumberField } from "numra";
 // Displays: 1,234.56  ← positive shown normally
 ```
 
-numra automatically parses `(1,234.56)` back to `-1234.56` when the user
+raqam automatically parses `(1,234.56)` back to `-1234.56` when the user
 pastes accounting-formatted values.
 
 ## Fixed decimal scale
@@ -52,7 +52,7 @@ bypassing JavaScript floating-point limitations:
 
 ```tsx
 import { useState } from "react";
-import { NumberField } from "numra";
+import { NumberField } from "raqam";
 
 function CryptoInput() {
   const [raw, setRaw] = useState<string | null>(null);
@@ -86,7 +86,7 @@ Show the converted value in real time using `NumberField.Formatted` + a read-onl
 
 ```tsx
 import { useState } from "react";
-import { NumberField, useNumberFieldFormat } from "numra";
+import { NumberField, useNumberFieldFormat } from "raqam";
 
 const USD_TO_EUR = 0.92;
 

--- a/docs/src/content/docs/recipes/formik.mdx
+++ b/docs/src/content/docs/recipes/formik.mdx
@@ -1,6 +1,6 @@
 ---
 title: Formik
-description: Integrating numra with Formik using the useFormik hook or Field component.
+description: Integrating raqam with Formik using the useFormik hook or Field component.
 ---
 
 ## Installation
@@ -13,7 +13,7 @@ npm install formik
 
 ```tsx
 import { useFormik } from "formik";
-import { NumberField } from "numra";
+import { NumberField } from "raqam";
 
 export function OrderForm() {
   const formik = useFormik({
@@ -122,7 +122,7 @@ export function PriceForm() {
 
 ## Tips
 
-- Use `setFieldValue("field", v)` (not Formik's `handleChange`) since numra
+- Use `setFieldValue("field", v)` (not Formik's `handleChange`) since raqam
   gives you a `number | null`, not a DOM event.
 - Use `setFieldTouched("field")` in `onBlur` to trigger touched state.
 - Pass the Formik error message directly to `NumberField.ErrorMessage` as

--- a/docs/src/content/docs/recipes/persian-ecommerce.mdx
+++ b/docs/src/content/docs/recipes/persian-ecommerce.mdx
@@ -15,13 +15,13 @@ This recipe shows how to build a complete Persian-language price input that:
 
 ```ts
 // app/layout.tsx or main.tsx
-import "numra/locales/fa";  // Register Persian digit block
+import "raqam/locales/fa";  // Register Persian digit block
 ```
 
 ## Basic toman input
 
 ```tsx
-import { NumberField } from "numra";
+import { NumberField } from "raqam";
 
 export function TomanInput() {
   return (
@@ -36,7 +36,7 @@ export function TomanInput() {
       <NumberField.Label>قیمت</NumberField.Label>  {/* "Price" */}
       <NumberField.Group>
         <NumberField.Decrement>−</NumberField.Decrement>
-        <NumberField.Input dir="ltr" />  {/* numra sets dir="ltr" internally */}
+        <NumberField.Input dir="ltr" />  {/* raqam sets dir="ltr" internally */}
         <NumberField.Increment>+</NumberField.Increment>
       </NumberField.Group>
     </NumberField.Root>
@@ -50,7 +50,7 @@ Displays: `۱٬۲۳۴ تومان`
 
 ```tsx
 import { useState } from "react";
-import { NumberField, useNumberFieldFormat } from "numra";
+import { NumberField, useNumberFieldFormat } from "raqam";
 
 export function ProductPriceEditor() {
   const [price, setPrice] = useState<number | null>(125000);
@@ -93,7 +93,7 @@ export function ProductPriceEditor() {
 
 Persian digit normalization is transparent:
 
-| User types | numra stores | Displays |
+| User types | raqam stores | Displays |
 |-----------|-------------|---------|
 | `۱۲۳۴` (Persian) | `1234` | `۱٬۲۳۴` |
 | `1234` (ASCII) | `1234` | `۱٬۲۳۴` |
@@ -142,7 +142,7 @@ If you want the `ریال` symbol from `Intl.NumberFormat`:
 For server-side price display in Persian:
 
 ```ts
-import { createFormatter } from "numra/server";
+import { createFormatter } from "raqam/server";
 
 const priceFormatter = createFormatter({
   locale: "fa-IR",
@@ -157,5 +157,5 @@ const displayPrice = priceFormatter.format(125000);
 <Aside>
   The `fa-IR` locale uses `٬` (Arabic thousands separator, U+066C) and `٫`
   (Arabic decimal separator, U+066B) — different from the ASCII `,` and `.`.
-  numra extracts these from `Intl.NumberFormat` automatically.
+  raqam extracts these from `Intl.NumberFormat` automatically.
 </Aside>

--- a/docs/src/content/docs/recipes/react-hook-form.mdx
+++ b/docs/src/content/docs/recipes/react-hook-form.mdx
@@ -1,12 +1,12 @@
 ---
 title: react-hook-form
-description: Integrating numra with react-hook-form using the Controller pattern.
+description: Integrating raqam with react-hook-form using the Controller pattern.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
 
-numra works naturally with react-hook-form via the `Controller` component.
-The key is: numra is `value`/`onChange` controlled, and `Controller` supplies
+raqam works naturally with react-hook-form via the `Controller` component.
+The key is: raqam is `value`/`onChange` controlled, and `Controller` supplies
 exactly those.
 
 ## Installation
@@ -19,7 +19,7 @@ npm install react-hook-form
 
 ```tsx
 import { useForm, Controller } from "react-hook-form";
-import { NumberField } from "numra";
+import { NumberField } from "raqam";
 
 type FormValues = {
   price: number | null;
@@ -71,9 +71,9 @@ export function PriceForm() {
 }
 ```
 
-## Using numra's built-in validate prop
+## Using raqam's built-in validate prop
 
-For simple validation, use numra's `validate` prop directly alongside
+For simple validation, use raqam's `validate` prop directly alongside
 react-hook-form — this updates `aria-invalid` and renders `NumberField.ErrorMessage`:
 
 ```tsx

--- a/docs/src/content/docs/recipes/shadcn-ui.mdx
+++ b/docs/src/content/docs/recipes/shadcn-ui.mdx
@@ -1,39 +1,39 @@
 ---
 title: shadcn/ui
-description: Wrapping numra with shadcn/ui primitives for a polished, design-system-consistent number input.
+description: Wrapping raqam with shadcn/ui primitives for a polished, design-system-consistent number input.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
 
 [shadcn/ui](https://ui.shadcn.com) provides styled, accessible components built
-on Radix UI. Since numra is headless, it integrates cleanly — just use numra's
+on Radix UI. Since raqam is headless, it integrates cleanly — just use raqam's
 hooks/components and apply shadcn's class names.
 
-## NumraInput component
+## RaqamInput component
 
-Create a reusable `NumraInput` component that follows the shadcn design language:
+Create a reusable `RaqamInput` component that follows the shadcn design language:
 
 ```tsx
-// components/numra-input.tsx
+// components/raqam-input.tsx
 "use client";
 
 import * as React from "react";
-import { NumberField } from "numra";
+import { NumberField } from "raqam";
 import { cn } from "@/lib/utils";
-import type { UseNumberFieldStateOptions } from "numra";
+import type { UseNumberFieldStateOptions } from "raqam";
 
-interface NumraInputProps extends UseNumberFieldStateOptions {
+interface RaqamInputProps extends UseNumberFieldStateOptions {
   label?: string;
   description?: string;
   className?: string;
 }
 
-export function NumraInput({
+export function RaqamInput({
   label,
   description,
   className,
   ...props
-}: NumraInputProps) {
+}: RaqamInputProps) {
   return (
     <NumberField.Root
       {...props}
@@ -72,10 +72,10 @@ export function NumraInput({
 ## Usage
 
 ```tsx
-import { NumraInput } from "@/components/numra-input";
+import { RaqamInput } from "@/components/raqam-input";
 
 // Basic
-<NumraInput
+<RaqamInput
   locale="en-US"
   label="Quantity"
   defaultValue={1}
@@ -84,7 +84,7 @@ import { NumraInput } from "@/components/numra-input";
 />
 
 // Currency
-<NumraInput
+<RaqamInput
   locale="en-US"
   label="Price"
   description="Enter the listing price in USD"
@@ -99,7 +99,7 @@ import { NumraInput } from "@/components/numra-input";
 
 ```tsx
 import { Badge } from "@/components/ui/badge";
-import { useNumberFieldFormat } from "numra";
+import { useNumberFieldFormat } from "raqam";
 
 function PriceBadge({ amount }: { amount: number }) {
   const formatted = useNumberFieldFormat(amount, {
@@ -120,7 +120,7 @@ function PriceBadge({ amount }: { amount: number }) {
 ```tsx
 import { useForm } from "react-hook-form";
 import { Form, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { NumberField } from "numra";
+import { NumberField } from "raqam";
 import { Controller } from "react-hook-form";
 
 export function ProductForm() {

--- a/docs/src/content/docs/recipes/tailwind.mdx
+++ b/docs/src/content/docs/recipes/tailwind.mdx
@@ -1,15 +1,15 @@
 ---
 title: Tailwind CSS
-description: Styling numra with Tailwind CSS — data attributes, focus rings, and dark mode.
+description: Styling raqam with Tailwind CSS — data attributes, focus rings, and dark mode.
 ---
 
-numra ships unstyled. Tailwind classes work naturally on all components.
+raqam ships unstyled. Tailwind classes work naturally on all components.
 Use `data-*` state attributes from the root element for conditional styling.
 
 ## Basic field
 
 ```tsx
-import { NumberField } from "numra";
+import { NumberField } from "raqam";
 
 export function PriceInput() {
   return (
@@ -36,7 +36,7 @@ export function PriceInput() {
 
 ## data-* attribute styling
 
-numra sets data attributes on the root element. Use Tailwind's `data-*` variant
+raqam sets data attributes on the root element. Use Tailwind's `data-*` variant
 for state-based styling:
 
 ```tsx

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "numra",
+  "name": "raqam",
   "version": "0.2.0",
   "description": "The definitive React number input: live formatting, full i18n, headless, accessible",
   "type": "module",

--- a/playwright-ct.config.ts
+++ b/playwright-ct.config.ts
@@ -35,13 +35,13 @@ export default defineConfig({
       // Inherit from project's vite-compatible tsconfig
       resolve: {
         alias: {
-          // Allow tests to import 'numra' as if installed
-          numra: "./src/index.ts",
-          "numra/locales/fa": "./src/locales/fa.ts",
-          "numra/locales/ar": "./src/locales/ar.ts",
-          "numra/locales/hi": "./src/locales/hi.ts",
-          "numra/locales/bn": "./src/locales/bn.ts",
-          "numra/locales/th": "./src/locales/th.ts",
+          // Allow tests to import 'raqam' as if installed
+          raqam: "./src/index.ts",
+          "raqam/locales/fa": "./src/locales/fa.ts",
+          "raqam/locales/ar": "./src/locales/ar.ts",
+          "raqam/locales/hi": "./src/locales/hi.ts",
+          "raqam/locales/bn": "./src/locales/bn.ts",
+          "raqam/locales/th": "./src/locales/th.ts",
         },
       },
     },

--- a/src/core/presets.ts
+++ b/src/core/presets.ts
@@ -3,7 +3,7 @@
  * number input patterns. Use these as the `formatOptions` prop value.
  *
  * @example
- * import { presets } from 'numra'
+ * import { presets } from 'raqam'
  * <NumberField.Root formatOptions={presets.currency('USD')} />
  * <NumberField.Root formatOptions={presets.percent} />
  * <NumberField.Root formatOptions={presets.compact} />
@@ -18,7 +18,7 @@ export const presets = {
 
   /**
    * Accounting currency — negatives shown as `(1,234.56)` instead of `-$1,234.56`.
-   * Requires the accounting format parser fix (built-in to numra).
+   * Requires the accounting format parser fix (built-in to raqam).
    */
   accounting: (code: string): Intl.NumberFormatOptions => ({
     style: "currency",

--- a/src/locales/ar.ts
+++ b/src/locales/ar.ts
@@ -4,7 +4,7 @@
  * Registers Arabic-Indic digit block (U+0660–U+0669).
  *
  * Usage:
- *   import 'numra/locales/ar'
+ *   import 'raqam/locales/ar'
  */
 import { registerLocale } from "../core/normalizer.js";
 

--- a/src/locales/bn.ts
+++ b/src/locales/bn.ts
@@ -4,7 +4,7 @@
  * Registers Bengali digit block (U+09E6–U+09EF).
  *
  * Usage:
- *   import 'numra/locales/bn'
+ *   import 'raqam/locales/bn'
  */
 import { registerLocale } from "../core/normalizer.js";
 

--- a/src/locales/fa.ts
+++ b/src/locales/fa.ts
@@ -9,7 +9,7 @@
  * Also registers the Arabic-Indic block for mixed-input scenarios.
  *
  * Usage:
- *   import 'numra/locales/fa'
+ *   import 'raqam/locales/fa'
  */
 import { registerLocale } from "../core/normalizer.js";
 

--- a/src/locales/hi.ts
+++ b/src/locales/hi.ts
@@ -4,7 +4,7 @@
  * Registers Devanagari digit block (U+0966–U+096F).
  *
  * Usage:
- *   import 'numra/locales/hi'
+ *   import 'raqam/locales/hi'
  */
 import { registerLocale } from "../core/normalizer.js";
 

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -3,7 +3,7 @@
  * Persian, Arabic, Bengali, Hindi, and Thai digit systems in one shot.
  *
  * Usage:
- *   import 'numra/locales'
+ *   import 'raqam/locales'
  *
  * Named re-exports alias each LOCALE_CODES array to avoid ambiguity:
  *   FA_LOCALE_CODES, AR_LOCALE_CODES, BN_LOCALE_CODES, HI_LOCALE_CODES, TH_LOCALE_CODES

--- a/src/locales/th.ts
+++ b/src/locales/th.ts
@@ -4,7 +4,7 @@
  * Registers Thai digit block (U+0E50–U+0E59).
  *
  * Usage:
- *   import 'numra/locales/th'
+ *   import 'raqam/locales/th'
  */
 import { registerLocale } from "../core/normalizer.js";
 

--- a/src/react/context.ts
+++ b/src/react/context.ts
@@ -18,7 +18,7 @@ export const NumberFieldContext = createContext<NumberFieldContextValue | null>(
 export function useNumberFieldContext(): NumberFieldContextValue {
   const ctx = useContext(NumberFieldContext);
   if (!ctx) {
-    throw new Error("[numra] NumberField sub-components must be used inside <NumberField.Root>.");
+    throw new Error("[raqam] NumberField sub-components must be used inside <NumberField.Root>.");
   }
   return ctx;
 }

--- a/src/react/useControllableState.ts
+++ b/src/react/useControllableState.ts
@@ -29,7 +29,7 @@ export function useControllableState<T>({
   ) {
     if (wasControlled.current !== isControlled) {
       console.warn(
-        `[numra] Component is changing from ${
+        `[raqam] Component is changing from ${
           wasControlled.current ? "controlled" : "uncontrolled"
         } to ${isControlled ? "controlled" : "uncontrolled"}. Decide between using a controlled or uncontrolled component and don't switch.`
       );

--- a/src/react/useNumberField.ts
+++ b/src/react/useNumberField.ts
@@ -51,7 +51,7 @@ export function useNumberField(
   const { step = 1, largeStep = step * 10, smallStep = step * 0.1 } = state.options;
 
   const autoId = useId();
-  const inputId = props.id ?? `numra-${autoId}`;
+  const inputId = props.id ?? `raqam-${autoId}`;
   const labelId = `${inputId}-label`;
   const descriptionId = `${inputId}-description`;
   const errorId = `${inputId}-error`;

--- a/src/stories/Accessibility.stories.tsx
+++ b/src/stories/Accessibility.stories.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { NumberField } from "../react/NumberField.js";
 
 const meta = {
-  title: "numra/Accessibility",
+  title: "raqam/Accessibility",
   component: NumberField.Root,
   tags: ["autodocs"],
 } satisfies Meta<typeof NumberField.Root>;

--- a/src/stories/AdvancedFormats.stories.tsx
+++ b/src/stories/AdvancedFormats.stories.tsx
@@ -55,7 +55,7 @@ export const Accounting: StoryObj = {
     <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
       <p style={{ margin: 0, fontSize: 13, color: "#6b7280" }}>
         Type a negative number. The accounting format shows negatives as (1,234.56).
-        numra automatically parses parentheses back to negative values.
+        raqam automatically parses parentheses back to negative values.
       </p>
       <NumberField.Root
         locale="en-US"

--- a/src/stories/BasicUsage.stories.tsx
+++ b/src/stories/BasicUsage.stories.tsx
@@ -4,7 +4,7 @@ import { NumberField } from "../react/NumberField.js";
 import { useNumberFieldFormat } from "../react/useNumberFieldFormat.js";
 
 const meta = {
-  title: "numra/Basic Usage",
+  title: "raqam/Basic Usage",
   component: NumberField.Root,
   tags: ["autodocs"],
 } satisfies Meta<typeof NumberField.Root>;
@@ -155,11 +155,11 @@ export const DataFocusedStyling: StoryObj = {
   render: () => (
     <div style={{ fontFamily: "system-ui", display: "flex", flexDirection: "column", gap: 12 }}>
       <style>{`
-        .numra-demo[data-focused] .numra-group {
+        .raqam-demo[data-focused] .raqam-group {
           border-color: #2563eb;
           box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
         }
-        .numra-demo[data-invalid] .numra-group {
+        .raqam-demo[data-invalid] .raqam-group {
           border-color: #dc2626;
         }
       `}</style>
@@ -170,13 +170,13 @@ export const DataFocusedStyling: StoryObj = {
       <NumberField.Root
         locale="en-US"
         defaultValue={42}
-        className="numra-demo"
+        className="raqam-demo"
       >
         <NumberField.Label style={{ fontSize: 13, fontWeight: 500 }}>
           Amount
         </NumberField.Label>
         <NumberField.Group
-          className="numra-group"
+          className="raqam-group"
           style={{
             display: "flex",
             border: "1px solid #d1d5db",

--- a/src/stories/Currency.stories.tsx
+++ b/src/stories/Currency.stories.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { NumberField } from "../react/NumberField.js";
 
 const meta = {
-  title: "numra/Currency & Formatting",
+  title: "raqam/Currency & Formatting",
   component: NumberField.Root,
   tags: ["autodocs"],
 } satisfies Meta<typeof NumberField.Root>;

--- a/src/stories/HookAPI.stories.tsx
+++ b/src/stories/HookAPI.stories.tsx
@@ -4,7 +4,7 @@ import { useNumberFieldState } from "../react/useNumberFieldState.js";
 import { useNumberField } from "../react/useNumberField.js";
 
 const meta: Meta = {
-  title: "numra/Hook API",
+  title: "raqam/Hook API",
   parameters: {
     docs: {
       description: {

--- a/src/stories/IMEInput.stories.tsx
+++ b/src/stories/IMEInput.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta = {
 
 When users type Chinese, Japanese, or Korean numbers via IME, the browser fires
 \`compositionstart\` / \`compositionend\` events wrapping the actual input.
-numra suspends live formatting during composition (to avoid corrupting partial
+raqam suspends live formatting during composition (to avoid corrupting partial
 composed characters) and applies full formatting when composition ends.
 
 **How to test:**
@@ -60,7 +60,7 @@ export const ZhCNInput: StoryObj = {
       <div style={{ padding: 12, background: "#fef3c7", borderRadius: 8, fontSize: 13 }}>
         <strong>Test with Chinese IME:</strong> Switch to Chinese input (Pinyin/Wubi),
         type &quot;123456&quot; — the IME may produce characters like &quot;一二三&quot; first.
-        numra suspends formatting during composition and applies it after you confirm.
+        raqam suspends formatting during composition and applies it after you confirm.
       </div>
       <NumberField.Root
         locale="zh-CN"

--- a/src/stories/Locales.stories.tsx
+++ b/src/stories/Locales.stories.tsx
@@ -9,7 +9,7 @@ import "../locales/hi.js";
 import "../locales/bn.js";
 
 const meta = {
-  title: "numra/Locales & i18n",
+  title: "raqam/Locales & i18n",
   component: NumberField.Root,
   tags: ["autodocs"],
 } satisfies Meta<typeof NumberField.Root>;

--- a/src/stories/ScrubArea.stories.tsx
+++ b/src/stories/ScrubArea.stories.tsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import { NumberField } from "../react/NumberField.js";
 
 const meta = {
-  title: "numra/ScrubArea",
+  title: "raqam/ScrubArea",
   component: NumberField.Root,
   tags: ["autodocs"],
 } satisfies Meta<typeof NumberField.Root>;


### PR DESCRIPTION
## Why

npm rejected `numra` as too similar to `numeral` and `namaa`:

```
E403 Package name too similar to existing packages numeral, namaa
```

## New name: `raqam` (رقم)

**رقم** means *digit / number* in Persian and Arabic — the languages whose numeral system gave the world mathematics. It's the most semantically accurate name possible for a number-input library, and it directly reflects the library's i18n-first identity.

- ✅ Available on npm (verified)
- ✅ 5 letters, easy to type
- ✅ `import { NumberField } from 'raqam'` reads naturally
- ✅ Strong brand story native to the Persian/Arabic community

## What changed (47 files)

| Area | Change |
|------|--------|
| `package.json` | `"name": "raqam"` |
| `README.md` | All imports, badges, prose, bundle table |
| `CHANGELOG.md` | All subpath and package references |
| `docs/**/*.mdx` | All import examples and prose (17 pages) |
| `src/locales/*.ts` | JSDoc import examples |
| `src/react/context.ts` | Error prefix `[raqam]` |
| `src/react/useNumberField.ts` | Auto-generated id prefix `raqam-` |
| `src/stories/**` | Storybook titles and CSS class names |
| `playwright-ct.config.ts` | Vite alias `raqam → ./src/index.ts` |
| `.size-limit.json` | Display names |
| `.github/workflows/release.yml` | PR title and commit message |
| `.github/ISSUE_TEMPLATE/*.yml` | Prose references |

**GitHub repo URL (`47vigen/numra`) and GitHub Pages base path (`/numra`) are unchanged** — only the npm package name changes.

## Verification

- ✅ 337 tests passing
- ✅ 0 TypeScript errors
- ✅ 24 Biome warnings (unchanged, all intentional)

https://claude.ai/code/session_01Uyd9F2JvGwEPU69DT9mc3y