### PR TITLE
Docs: React demos, Sandpack playground, CI Node 24

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- Documentation site: React demos, Sandpack playground, hero showcase updates.
- **CI:** Deploy Docs workflow uses Node 24 so Astro 6 builds succeed on GitHub Actions (requires Node ≥22.12).

## Verification

- `pnpm docs:build` locally
- Pre-commit: typecheck + tests passed on last push

Made with [Cursor](https://cursor.com)