### PR TITLE
docs: add raqam agent skill for package consumers

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,42 @@
+# Agent skills (raqam)
+
+This directory holds **agent skills** for developers using the `[raqam](https://www.npmjs.com/package/raqam)` npm package. They are **not** required to work inside the raqam library repo itself.
+
+## Published skill
+
+
+| Skill | Folder           | Description                                                  |
+| ----- | ---------------- | ------------------------------------------------------------ |
+| raqam | [raqam/](raqam/) | Full-stack guidance for the raqam React number-input library |
+
+
+## Install with the skills CLI
+
+From a **project** that should load the skill (after this repo is on GitHub):
+
+```bash
+# Install only the raqam skill from this repository
+npx skills add https://github.com/47vigen/raqam/tree/main/skills/raqam
+```
+
+Or clone locally:
+
+```bash
+npx skills add /path/to/raqam/skills/raqam
+```
+
+List what will be installed:
+
+```bash
+npx skills add https://github.com/47vigen/raqam --list
+```
+
+(Use the repo root if you add multiple skills later; the CLI discovers `skills/*/SKILL.md`.)
+
+## skills.sh
+
+The public directory at [skills.sh](https://skills.sh/) reflects **anonymous install telemetry** from the `skills` CLI, not a separate manual upload. Publishing is: **push the skill to a public Git URL** and share/install it with `npx skills add …` as above. See [vercel-labs/skills](https://github.com/vercel-labs/skills) for the CLI and [Agent Skills](https://agentskills.io) for the spec.
+
+## Layout
+
+Each skill is a directory containing at minimum `SKILL.md` (YAML frontmatter + instructions). Optional files here follow the usual pattern: `reference.md`, `examples.md`, `scripts/`.

--- a/skills/raqam/SKILL.md
+++ b/skills/raqam/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: raqam
+description: Teaches the raqam React number-input library — headless NumberField compound components, useNumberFieldState/useNumberField hooks, Intl presets, locale plugins (fa/ar/bn/hi/th), raqam/server formatting, validation, ScrubArea, accessibility, and form integration. Use when building or debugging currency/percent/unit fields, live-formatted inputs, non-Latin digits, react-hook-form/Formik, Next.js App Router client vs server formatting, or any raqam API.
+---
+
+# raqam (React number input)
+
+## Canonical sources (read these for full detail)
+
+- **Docs site:** [https://47vigen.github.io/raqam/](https://47vigen.github.io/raqam/)
+- **README (quick API tables):** [https://github.com/47vigen/raqam/blob/main/README.md](https://github.com/47vigen/raqam/blob/main/README.md)
+- **Package:** [https://www.npmjs.com/package/raqam](https://www.npmjs.com/package/raqam)
+- **Issues:** [https://github.com/47vigen/raqam/issues](https://github.com/47vigen/raqam/issues)
+
+Do not assume paths inside the raqam repo; always prefer the docs URLs above. Version in this skill reflects the library at publish time; confirm the current version on npm.
+
+## What raqam is
+
+- **Live formatting while typing** using `Intl.NumberFormat` (cursor-safe algorithm; not “format on blur only”).
+- **Headless:** no default styles; compound `NumberField.*` or raw hooks.
+- **i18n:** locale-driven separators and symbols; optional **locale plugins** for non-Latin digits (Persian, Arabic, Bengali, Hindi, Thai).
+- **Accessibility:** WAI-ARIA `spinbutton`, `aria-valuenow` / `aria-valuetext`, keyboard model (↑↓ Home End PgUp/PgDn, modifiers for step sizes).
+
+Peer dependencies: **React 18+** (and `react-dom`).
+
+## Install
+
+```bash
+npm install raqam
+# or: pnpm add raqam / yarn add raqam
+```
+
+## Entry points
+
+| Import | Use for |
+|--------|---------|
+| `raqam` | `NumberField`, `useNumberFieldState`, `useNumberField`, `useNumberFieldFormat`, `presets` |
+| `raqam/react` | Same hooks/components (alternate entry; see docs) |
+| `raqam/core` | No React — `createFormatter`, `createParser`, `registerLocale`, `presets` |
+| `raqam/server` | **Alias of `raqam/core`** — safe in RSC, edge, Node (zero React deps) |
+| `raqam/locales/<lang>` | Side-effect plugins: `fa`, `ar`, `bn`, `hi`, `th` (tree-shakeable) |
+| `raqam/locales` | Registers all built-in locale plugins |
+
+Bundle sizes and export map: see README and [Getting Started](https://47vigen.github.io/raqam/getting-started/).
+
+## Choose an API
+
+**Compound components (default)** — less boilerplate, context-wired parts:
+
+- Guide: [NumberField components](https://47vigen.github.io/raqam/api/components/)
+- `NumberField.Root` + `Label`, `Group`, `Input`, `Increment`/`Decrement`, `Description`, `ErrorMessage`, `HiddenInput`, `ScrubArea`, `Formatted`, etc.
+
+**Hook API** — full control over DOM and styling:
+
+- [useNumberFieldState](https://47vigen.github.io/raqam/api/use-number-field-state/) — state machine (`inputValue`, `numberValue`, `rawValue`, validation, scrubbing).
+- [useNumberField](https://47vigen.github.io/raqam/api/use-number-field/) — ARIA props + handlers; requires `inputRef` to the `<input>`.
+
+## Behavior essentials
+
+- **`locale`:** BCP 47 tag; drives `Intl.NumberFormat` / parsing.
+- **`formatOptions`:** standard `Intl.NumberFormatOptions`; use **`presets`** for common cases — [Format presets](https://47vigen.github.io/raqam/api/presets/).
+- **Controlled vs uncontrolled:** `value`/`onChange` vs `defaultValue`. `onChange` fires on **commit** (blur, Enter, steppers), not every keystroke — see [Getting Started](https://47vigen.github.io/raqam/getting-started/).
+- **Constraints:** `minValue`, `maxValue`, `step`, `largeStep`, `smallStep`, `clampBehavior`, `allowOutOfRange`, `allowNegative`, `allowDecimal`, `fixedDecimalScale`.
+- **Validation:** `validate` returning `true` / error string; pairs with `NumberField.ErrorMessage`.
+- **Precision / finance:** `onRawChange` and `state.rawValue` for exact string before float conversion; optional custom `formatValue` / `parseValue`.
+- **Display-only:** [useNumberFieldFormat](https://47vigen.github.io/raqam/api/use-number-field-format/) on the client; **`createFormatter` from `raqam/server`** on the server.
+
+## Locales and RTL
+
+- [Locales & i18n](https://47vigen.github.io/raqam/guides/locales/) — switching locales, plugins table, `registerLocale` escape hatch.
+- [RTL support](https://47vigen.github.io/raqam/guides/rtl/) — RTL layout and behavior.
+
+## Next.js
+
+- [Next.js App Router](https://47vigen.github.io/raqam/guides/nextjs/) — `"use client"` for inputs; `raqam/server` for Server Components and edge-safe formatting.
+
+## Forms and UI stacks
+
+- [react-hook-form](https://47vigen.github.io/raqam/recipes/react-hook-form/)
+- [Formik](https://47vigen.github.io/raqam/recipes/formik/)
+- [Tailwind CSS](https://47vigen.github.io/raqam/recipes/tailwind/)
+- [shadcn/ui](https://47vigen.github.io/raqam/recipes/shadcn-ui/)
+- [Financial app patterns](https://47vigen.github.io/raqam/recipes/financial/)
+- [Persian e-commerce](https://47vigen.github.io/raqam/recipes/persian-ecommerce/)
+
+## Styling and UX
+
+- Root **`data-*` attributes** for CSS (`data-focused`, `data-invalid`, `data-disabled`, `data-readonly`, `data-rtl`, `data-scrubbing`) — see README and components doc.
+- **ScrubArea:** pointer-lock drag to change value — [components doc](https://47vigen.github.io/raqam/api/components/).
+- **`render` prop** on compound parts to swap elements without `asChild`.
+
+## Accessibility
+
+- [Accessibility guide](https://47vigen.github.io/raqam/guides/accessibility/) — `spinbutton`, keyboard table, focus model (Tab targets input; steppers use arrow keys).
+
+## Interactive exploration
+
+- [Playground](https://47vigen.github.io/raqam/playground/)
+
+## When the model needs more detail
+
+1. Open the **exact doc page** from the links above (prefer over guessing APIs).
+2. Use **Context7** / current package docs for npm `raqam` if behavior vs version matters.
+3. For exhaustive option tables and extra props, see [reference.md](reference.md).
+4. For copy-paste patterns, see [examples.md](examples.md).
+
+## Docs site map (official)
+
+| Topic | URL |
+|--------|-----|
+| Getting Started | [https://47vigen.github.io/raqam/getting-started/](https://47vigen.github.io/raqam/getting-started/) |
+| Playground | [https://47vigen.github.io/raqam/playground/](https://47vigen.github.io/raqam/playground/) |
+| useNumberFieldState | [https://47vigen.github.io/raqam/api/use-number-field-state/](https://47vigen.github.io/raqam/api/use-number-field-state/) |
+| useNumberField | [https://47vigen.github.io/raqam/api/use-number-field/](https://47vigen.github.io/raqam/api/use-number-field/) |
+| NumberField components | [https://47vigen.github.io/raqam/api/components/](https://47vigen.github.io/raqam/api/components/) |
+| useNumberFieldFormat | [https://47vigen.github.io/raqam/api/use-number-field-format/](https://47vigen.github.io/raqam/api/use-number-field-format/) |
+| Format presets | [https://47vigen.github.io/raqam/api/presets/](https://47vigen.github.io/raqam/api/presets/) |
+| Locales & i18n | [https://47vigen.github.io/raqam/guides/locales/](https://47vigen.github.io/raqam/guides/locales/) |
+| RTL | [https://47vigen.github.io/raqam/guides/rtl/](https://47vigen.github.io/raqam/guides/rtl/) |
+| Next.js | [https://47vigen.github.io/raqam/guides/nextjs/](https://47vigen.github.io/raqam/guides/nextjs/) |
+| Accessibility | [https://47vigen.github.io/raqam/guides/accessibility/](https://47vigen.github.io/raqam/guides/accessibility/) |
+
+Recipes are linked from the [docs homepage](https://47vigen.github.io/raqam/) sidebar.

--- a/skills/raqam/examples.md
+++ b/skills/raqam/examples.md
@@ -1,0 +1,146 @@
+# raqam — patterns and examples
+
+Prefer the **live playground** for experimentation: [https://47vigen.github.io/raqam/playground/](https://47vigen.github.io/raqam/playground/)
+
+## Minimal NumberField
+
+```tsx
+import { NumberField } from "raqam";
+
+export function QuantityInput() {
+  return (
+    <NumberField.Root locale="en-US" defaultValue={1} minValue={0}>
+      <NumberField.Label>Quantity</NumberField.Label>
+      <NumberField.Group>
+        <NumberField.Decrement>−</NumberField.Decrement>
+        <NumberField.Input />
+        <NumberField.Increment>+</NumberField.Increment>
+      </NumberField.Group>
+    </NumberField.Root>
+  );
+}
+```
+
+## Currency + presets
+
+```tsx
+import { presets, NumberField } from "raqam";
+
+<NumberField.Root
+  locale="en-US"
+  formatOptions={presets.currency("USD")}
+  defaultValue={0}
+  minValue={0}
+>
+  <NumberField.Label>Price</NumberField.Label>
+  <NumberField.Input />
+</NumberField.Root>
+```
+
+More preset names and options: [Format presets](https://47vigen.github.io/raqam/api/presets/).
+
+## Persian locale plugin + suffix
+
+```tsx
+import "raqam/locales/fa";
+import { NumberField } from "raqam";
+
+<NumberField.Root
+  locale="fa-IR"
+  formatOptions={{ style: "currency", currency: "IRR" }}
+  suffix=" تومان"
+/>
+```
+
+## Hooks (state + behavior)
+
+```tsx
+import { useRef } from "react";
+import { useNumberFieldState, useNumberField } from "raqam";
+
+function PriceInput() {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const state = useNumberFieldState({
+    locale: "en-US",
+    formatOptions: { style: "currency", currency: "USD" },
+    minValue: 0,
+    defaultValue: 1234.56,
+  });
+  const { inputProps, labelProps, incrementButtonProps, decrementButtonProps } =
+    useNumberField({ label: "Price" }, state, inputRef);
+
+  return (
+    <div>
+      <label {...labelProps}>Price</label>
+      <button {...decrementButtonProps}>−</button>
+      <input ref={inputRef} {...inputProps} />
+      <button {...incrementButtonProps}>+</button>
+    </div>
+  );
+}
+```
+
+## Display-only (client)
+
+```tsx
+import { useNumberFieldFormat } from "raqam";
+
+function PriceDisplay({ price }: { price: number }) {
+  const formatted = useNumberFieldFormat(price, {
+    locale: "en-US",
+    formatOptions: { style: "currency", currency: "USD" },
+  });
+  return <span>{formatted}</span>;
+}
+```
+
+## Server-side formatting (RSC, no React in formatter)
+
+```tsx
+import { createFormatter } from "raqam/server";
+
+const formatter = createFormatter({
+  locale: "en-US",
+  formatOptions: { style: "currency", currency: "USD" },
+});
+const displayPrice = formatter.format(1234.56);
+```
+
+## react-hook-form (Controller)
+
+Full recipe: [https://47vigen.github.io/raqam/recipes/react-hook-form/](https://47vigen.github.io/raqam/recipes/react-hook-form/)
+
+Sketch:
+
+```tsx
+<Controller
+  name="price"
+  control={control}
+  render={({ field, fieldState }) => (
+    <NumberField.Root
+      locale="en-US"
+      formatOptions={{ style: "currency", currency: "USD" }}
+      value={field.value}
+      onChange={field.onChange}
+      onBlur={field.onBlur}
+      validate={() => fieldState.error?.message ?? true}
+    >
+      <NumberField.Label>Price</NumberField.Label>
+      <NumberField.Input />
+      <NumberField.ErrorMessage />
+    </NumberField.Root>
+  )}
+/>
+```
+
+## CSS hooks (data attributes)
+
+Style using attributes on `NumberField.Root`, for example `data-focused`, `data-invalid`, `data-disabled`, `data-readonly`, `data-rtl`, `data-scrubbing`. See README and [components](https://47vigen.github.io/raqam/api/components/).
+
+## More recipes (external)
+
+- [Formik](https://47vigen.github.io/raqam/recipes/formik/)
+- [Tailwind CSS](https://47vigen.github.io/raqam/recipes/tailwind/)
+- [shadcn/ui](https://47vigen.github.io/raqam/recipes/shadcn-ui/)
+- [Financial](https://47vigen.github.io/raqam/recipes/financial/)
+- [Persian e-commerce](https://47vigen.github.io/raqam/recipes/persian-ecommerce/)

--- a/skills/raqam/reference.md
+++ b/skills/raqam/reference.md
@@ -1,0 +1,52 @@
+# raqam — reference digest
+
+Use this file for **quick lookup**. Authoritative detail lives in the official docs and README (see [SKILL.md](SKILL.md) canonical links).
+
+## Official references (external)
+
+- **README API tables:** [https://github.com/47vigen/raqam/blob/main/README.md](https://github.com/47vigen/raqam/blob/main/README.md)
+- **useNumberFieldState options & state shape:** [https://47vigen.github.io/raqam/api/use-number-field-state/](https://47vigen.github.io/raqam/api/use-number-field-state/)
+- **useNumberField props & NumberFieldAria keys:** [https://47vigen.github.io/raqam/api/use-number-field/](https://47vigen.github.io/raqam/api/use-number-field/)
+- **NumberField.* components:** [https://47vigen.github.io/raqam/api/components/](https://47vigen.github.io/raqam/api/components/)
+- **presets:** [https://47vigen.github.io/raqam/api/presets/](https://47vigen.github.io/raqam/api/presets/)
+
+## useNumberFieldState — option groups (summary)
+
+| Area | Examples |
+|------|-----------|
+| Value | `value`, `defaultValue`, `onChange`, `onRawChange` |
+| Locale / format | `locale`, `formatOptions`, `prefix`, `suffix`, `fixedDecimalScale`, `liveFormat` |
+| Bounds / step | `minValue`, `maxValue`, `step`, `largeStep`, `smallStep`, `clampBehavior`, `allowOutOfRange` |
+| Input rules | `allowNegative`, `allowDecimal`, `maximumFractionDigits`, `minimumFractionDigits` |
+| Validation | `validate` |
+| Custom | `formatValue`, `parseValue` |
+| UX timing | `stepHoldDelay`, `stepHoldInterval`, `disabled`, `readOnly` |
+
+## NumberField.Root — extras (summary)
+
+Beyond state options, the component API adds callbacks such as **`onValueChange`** (with reason) and **`onValueCommitted`**. See [components doc](https://47vigen.github.io/raqam/api/components/).
+
+## useNumberField — notable props
+
+- **`copyBehavior`:** `"formatted"` | `"raw"` | `"number"` — clipboard semantics ([doc](https://47vigen.github.io/raqam/api/use-number-field/)).
+- **`allowMouseWheel`:** opt-in wheel nudging (see docs).
+
+## Locale plugins (built-in)
+
+| Import | Scripts / notes |
+|--------|------------------|
+| `raqam/locales/fa` | Persian digits |
+| `raqam/locales/ar` | Arabic-Indic digits |
+| `raqam/locales/bn` | Bengali digits |
+| `raqam/locales/hi` | Devanagari digits |
+| `raqam/locales/th` | Thai digits |
+
+Full table and `registerLocale` custom digits: [Locales & i18n](https://47vigen.github.io/raqam/guides/locales/).
+
+## Server / core
+
+`raqam/server` and `raqam/core` expose **`createFormatter`**, **`createParser`**, **`normalizeDigits`**, **`registerLocale`**, **`presets`**. Details: [Next.js guide](https://47vigen.github.io/raqam/guides/nextjs/) and package README.
+
+## Types (TypeScript)
+
+Export names like `UseNumberFieldStateOptions`, `NumberFieldState`, `UseNumberFieldProps`, `NumberFieldAria`, `ChangeReason` — see [Getting Started](https://47vigen.github.io/raqam/getting-started/) TypeScript section and published `.d.ts` on npm.

--- a/skills/raqam/scripts/README.md
+++ b/skills/raqam/scripts/README.md
@@ -1,0 +1,5 @@
+# scripts
+
+This skill does **not** ship executable scripts. Logic belongs in the consuming app; API surface is documented in [SKILL.md](../SKILL.md) and the official raqam docs.
+
+If you add a verified helper script later (for example a codegen or migration tool), document required runtime and usage here.


### PR DESCRIPTION
Adds a publishable agent skill under `skills/raqam/` for developers using the raqam npm package: `SKILL.md`, `reference.md`, `examples.md`, and `skills/README.md` with install notes for the skills CLI and skills.sh.

External documentation links point to the official docs site, npm, and GitHub; internal cross-links stay within the skill folder.

Made with [Cursor](https://cursor.com)