### PR TITLE
docs: align all documentation with the shipped API (accuracy, dedup, DX)

### DIFF
--- a/.changeset/docs-accuracy-overhaul.md
+++ b/.changeset/docs-accuracy-overhaul.md
@@ -1,0 +1,16 @@
+---
+"raqam": patch
+---
+
+docs: align all documentation with the shipped API
+
+- Correct README bundle-size figures to the real CI-enforced numbers
+  (core ~1.84 KB, react ~8.1 KB, full ~8.3 KB, locale plugin <200 B).
+- Fix the README API tables: move `formatValue`/`parseValue` to the state hook,
+  document `onValueCommitted`, `liveFormat`, `required`, and `className`/`style`,
+  and clarify that `useNumberFieldFormat` is client-only (use `createFormatter`
+  from `raqam/server` in RSC).
+- Document the correct `data-*` attributes (including `data-required` and
+  `data-scrubbing`) and that `data-rtl` is set on the input element.
+
+No runtime changes — documentation only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,12 +126,14 @@
 
 #### Bundle sizes
 
-| Entry              | Gzipped  |
-| ------------------ | -------- |
-| `raqam/core`       | < 2 KB   |
-| `raqam`            | < 9 KB   |
-| `raqam/react`      | < 8 KB   |
-| `raqam/locales/fa` | < 0.3 KB |
+Min + brotli (including dependencies), enforced in CI via `.size-limit.json`:
+
+| Entry              | Size     | CI budget |
+| ------------------ | -------- | --------- |
+| `raqam/core`       | ~1.84 KB | 2 KB      |
+| `raqam`            | ~8.3 KB  | 12 KB     |
+| `raqam/react`      | ~8.1 KB  | 10 KB     |
+| `raqam/locales/fa` | 189 B    | 0.3 KB    |
 
 #### Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,12 @@ src/
 └── stories/        # Storybook stories
 ```
 
+For the **design rationale** behind this architecture — why input is always
+`type="text"`, how the cursor-preservation algorithm works, the i18n/RTL
+strategy, and the full set of ADRs — see [`DEFINITION.md`](DEFINITION.md) (the
+original design spec). For the user-facing API, see [`README.md`](README.md) and
+the [docs site](https://47vigen.github.io/raqam/).
+
 ## Testing
 
 All code must have tests. Run:
@@ -58,17 +64,31 @@ pnpm test:coverage   # with coverage report
 
 ## Adding a locale plugin
 
-Locale plugins live in `src/locales/`. Each plugin registers digit blocks via `registerLocale()`:
+Locale plugins live in `src/locales/`. Each plugin is a side-effecting module
+that registers one or more digit blocks via `registerLocale()` and exports the
+BCP 47 tags it covers:
 
 ```ts
 // src/locales/my-locale.ts
 import { registerLocale } from '../core/normalizer.js'
 
-// Register digit codepoint range [start, end] inclusive
-registerLocale({ digits: [0xXXX0, 0xXXX9] })
+// digitBlocks is an array of [start, end] codepoint ranges (inclusive)
+registerLocale({ digitBlocks: [[0xXXX0, 0xXXX9]] })
+
+/** BCP 47 locale tags this plugin covers. */
+export const LOCALE_CODES = ['xx', 'xx-YY'] as const
 ```
 
-Add a corresponding test verifying digit normalization round-trips.
+Then re-export it from `src/locales/index.ts` (aliasing the codes) so
+`import 'raqam/locales'` registers everything:
+
+```ts
+export { LOCALE_CODES as XX_LOCALE_CODES } from './my-locale.js'
+```
+
+Add a corresponding test verifying digit normalization round-trips, and a
+`tsup` entry in `tsup.config.ts` if the plugin should ship as its own subpath
+(`raqam/locales/xx`).
 
 ## Commit style
 

--- a/DEFINITION.md
+++ b/DEFINITION.md
@@ -1,6 +1,22 @@
 # The definitive React number input: design specification
 
-**No existing React number input package combines live formatting, true headless composability, full i18n digit support, and gold-standard accessibility into one solution.** This document specifies exactly how to build one. After analyzing every major competitor — Base UI, React Aria, Mantine, Chakra, rc-input-number, and react-number-format — we identified a critical gap: libraries excel at one or two of these dimensions but fail at the rest. React Aria has the best accessibility and i18n parsing (30+ locales, Arabic/Persian digit input) but only formats on blur. Mantine wraps react-number-format for live formatting but is locked to its design system. Base UI is truly headless with an innovative ScrubArea but lacks live formatting and i18n digit parsing. **This package — tentatively named `raqam` — unifies all four pillars into a single, tree-shakeable, zero-dependency library shipping both a Hook API and a Headless Component API.**
+> **📜 Historical design document.** This is the original specification written
+> **before** raqam was implemented. It captures the research, gap analysis, and
+> architecture decisions (ADRs) that shaped the library — kept as design
+> rationale for contributors. It is **not** API documentation and some details
+> describe the *plan*, not what shipped (targets, names, type sketches, and the
+> week-by-week roadmap have since changed).
+>
+> For the **shipped API and current usage**, see:
+> - [`README.md`](README.md) — quick start + API tables
+> - The docs site — <https://47vigen.github.io/raqam/>
+> - [`CHANGELOG.md`](CHANGELOG.md) — what actually shipped per release
+>
+> The architecture rationale below (ADRs §4, the cursor engine §6, the i18n/RTL
+> strategy §7) remains accurate and is the best place to understand *why* raqam
+> is built the way it is.
+
+**No existing React number input package combines live formatting, true headless composability, full i18n digit support, and gold-standard accessibility into one solution.** This document specifies exactly how to build one. After analyzing every major competitor — Base UI, React Aria, Mantine, Chakra, rc-input-number, and react-number-format — we identified a critical gap: libraries excel at one or two of these dimensions but fail at the rest. React Aria has the best accessibility and i18n parsing (30+ locales, Arabic/Persian digit input) but only formats on blur. Mantine wraps react-number-format for live formatting but is locked to its design system. Base UI is truly headless with an innovative ScrubArea but lacks live formatting and i18n digit parsing. **This package — `raqam` — unifies all four pillars into a single, tree-shakeable, zero-dependency library shipping both a Hook API and a Headless Component API.**
 
 ---
 
@@ -154,7 +170,7 @@ The core always handles Latin digits and `Intl.NumberFormat` output. Locale plug
 
 **Decision**: Ship as one npm package with subpath exports, not a monorepo of separate packages.
 
-**Rationale**: The codebase is tightly coupled (formatting logic feeds into hooks which feed into components). Separate packages would create version synchronization headaches. Subpath exports provide the same tree-shaking benefits: `import { useNumberField } from 'raqam'` for the hook, `import { NumberField } from 'raqam/components'` for headless components, `import 'raqam/locales/fa'` for Persian support.
+**Rationale**: The codebase is tightly coupled (formatting logic feeds into hooks which feed into components). Separate packages would create version synchronization headaches. Subpath exports provide the same tree-shaking benefits: `import { useNumberField } from 'raqam'` for the hook, `import { NumberField } from 'raqam'` (or `raqam/react`) for headless components, `import 'raqam/locales/fa'` for Persian support. (As shipped, the entry points are `raqam`, `raqam/core`, `raqam/react`, `raqam/server`, and `raqam/locales/*` — there is no `raqam/components` subpath.)
 
 ### ADR-007: render prop pattern for element replacement
 
@@ -296,7 +312,7 @@ function useNumberField(
 </NumberField.Root>
 
 // With ScrubArea
-<NumberField.Root defaultValue={50} min={0} max={100}>
+<NumberField.Root defaultValue={50} minValue={0} maxValue={100}>
   <NumberField.ScrubArea direction="horizontal" pixelSensitivity={2}>
     <NumberField.Label>Opacity</NumberField.Label>
     <NumberField.ScrubAreaCursor>

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | Truly headless | ✅ | ✅ | ❌ | ✅ |
 | i18n digit input (Persian ۱۲۳, Arabic ١٢٣…) | ❌ | ✅ | ❌ | ✅ |
 | WAI-ARIA spinbutton | ✅ | ✅✅ | ⚠️ | ✅✅ |
-| Bundle size | ~10 KB | ~30 KB | ~60 KB | **~1.7 KB core** |
+| Bundle size | ~10 KB | ~30 KB | ~60 KB | **~1.8 KB core** |
 
 No existing package combines all four. raqam does.
 
@@ -184,9 +184,14 @@ Uses the Pointer Lock API so the cursor never hits the screen edge during drag.
 [data-invalid]   { border-color: red; }
 [data-disabled]  { opacity: 0.5; }
 [data-readonly]  { background: #f5f5f5; }
-[data-rtl]       { /* RTL-specific overrides */ }
+[data-required]  { /* required-field styling */ }
 [data-scrubbing] { cursor: ew-resize; }
+[data-rtl]       { /* RTL-specific overrides (set on the input element) */ }
 ```
+
+`data-focused`, `data-invalid`, `data-disabled`, `data-readonly`, `data-required`,
+and `data-scrubbing` are set on `NumberField.Root`; `data-rtl` (plus the state
+attributes) is set on the `NumberField.Input` element.
 
 ## 🔗 react-hook-form integration
 
@@ -272,14 +277,18 @@ State management hook — returns `NumberFieldState`.
 | `validate` | `(v: number \| null) => boolean \| string \| null` | — | Custom validation |
 | `prefix` | `string` | — | String prefix (e.g. `"$"`) |
 | `suffix` | `string` | — | String suffix (e.g. `" تومان"`) |
+| `liveFormat` | `boolean` | `true` | Format while typing (disable for IME locales) |
 | `disabled` | `boolean` | `false` | Disable the field |
 | `readOnly` | `boolean` | `false` | Read-only mode |
+| `required` | `boolean` | `false` | Mark the field as required |
+
+Also accepts `maximumFractionDigits`, `minimumFractionDigits`, `formatValue`,
+and `parseValue` — see the [full options reference](https://47vigen.github.io/raqam/api/use-number-field-state/).
 
 ### `useNumberField(props, state, inputRef)`
 
-Behavior hook — returns `NumberFieldAria` prop objects for each element.
-
-Additional props beyond state options:
+Behavior hook — returns `NumberFieldAria` prop objects for each element. Accepts
+every `useNumberFieldState` option plus the behavior-only props below:
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
@@ -287,18 +296,23 @@ Additional props beyond state options:
 | `copyBehavior` | `"formatted" \| "raw" \| "number"` | `"formatted"` | Clipboard content on copy |
 | `stepHoldDelay` | `number` | `400` | Press-and-hold initial delay (ms) |
 | `stepHoldInterval` | `number` | `200` | Press-and-hold repeat interval (ms) |
-| `formatValue` | `(value: number) => string` | — | Custom format function |
-| `parseValue` | `(input: string) => { value: number \| null; isIntermediate: boolean }` | — | Custom parse function |
+| `label` / `name` / `id` / `aria-*` | `string` | — | Labelling, form name, and id wiring |
+
+→ Full reference: [`useNumberField`](https://47vigen.github.io/raqam/api/use-number-field/).
 
 ### `NumberField.Root` extra props
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `onValueChange` | `(value, { reason, formattedValue }) => void` | Fires with change reason |
+| `onValueChange` | `(value, { reason, formattedValue }) => void` | Fires on every change, with the change `reason` |
+| `onValueCommitted` | `(value, { reason }) => void` | Fires only on commit (`reason: "blur" \| "keyboard"`) |
+| `className` / `style` | `string` / `CSSProperties` | Applied to the root wrapper `<div>` |
 
 ### `useNumberFieldFormat(value, options)`
 
-Display-only formatting hook. Returns a formatted string. Zero state overhead — safe in RSC via `raqam/server`.
+Display-only formatting hook (client-only — it carries `"use client"`). Returns a
+formatted string with zero state overhead. For React Server Components, SSR, or
+Edge, use `createFormatter` from `raqam/server` instead (shown above).
 
 ### `NumberField.*` components
 
@@ -329,14 +343,15 @@ Every component accepts a `render` prop for element replacement:
 
 ## 📦 Bundle size
 
-Actual sizes (brotli compressed):
+Measured min + brotli (including dependencies), enforced in CI via
+[`.size-limit.json`](.size-limit.json):
 
-| Entry | Size |
-|-------|------|
-| `raqam/core` | ~1.7 KB |
-| `raqam` (hooks + components) | ~7 KB |
-| `raqam/react` | ~6.8 KB |
-| `raqam/locales/fa` | ~200 B |
+| Entry | Size | CI budget |
+|-------|------|-----------|
+| `raqam/core` | ~1.84 KB | 2 KB |
+| `raqam` (hooks + components) | ~8.3 KB | 12 KB |
+| `raqam/react` | ~8.1 KB | 10 KB |
+| `raqam/locales/fa` | 189 B | 0.3 KB |
 
 ## 📄 License
 

--- a/docs/src/components/playground/playground-templates.ts
+++ b/docs/src/components/playground/playground-templates.ts
@@ -1,5 +1,5 @@
 /** Keep in sync with published `raqam` when releasing. */
-export const RAQAM_VERSION = "0.2.2";
+export const RAQAM_VERSION = "0.2.4";
 
 export type PlaygroundTemplateId = "starter" | "currency" | "persian";
 
@@ -71,7 +71,7 @@ export default function App(): JSX.Element {
         <NumberField.Group style={{ display: "flex", alignItems: "center", border: "1px solid #ccc", borderRadius: 8, overflow: "hidden" }}>
           <NumberField.Decrement style={{ padding: "8px 12px", border: "none", background: "#f5f5f5", cursor: "pointer" }}>−</NumberField.Decrement>
           <NumberField.Input
-            style={{ flex: 1, padding: "8px 10px", border: "none", outline: "none", minWidth: 80, direction: "rtl" }}
+            style={{ flex: 1, padding: "8px 10px", border: "none", outline: "none", minWidth: 80 }}
           />
           <NumberField.Increment style={{ padding: "8px 12px", border: "none", background: "#f5f5f5", cursor: "pointer" }}>+</NumberField.Increment>
         </NumberField.Group>

--- a/docs/src/content/docs/api/advanced-primitives.mdx
+++ b/docs/src/content/docs/api/advanced-primitives.mdx
@@ -101,7 +101,7 @@ function CustomAdornment() {
 }
 ```
 
-The context value exposes:
+The context value (type `NumberFieldContextValue`, also exported from `raqam`) exposes:
 
 | Key | Description |
 |-----|-------------|

--- a/docs/src/content/docs/api/components.mdx
+++ b/docs/src/content/docs/api/components.mdx
@@ -40,7 +40,10 @@ Only `Root` and `Input` are required. All others are optional.
 
 ## `NumberField.Root`
 
-Context provider. Accepts all `UseNumberFieldStateOptions` props plus:
+Context provider. Accepts **every** [`useNumberFieldState`](/api/use-number-field-state)
+and [`useNumberField`](/api/use-number-field) option (`step`, `formatOptions`,
+`validate`, `copyBehavior`, `stepHoldDelay`, `label`, `aria-*`, …) — the most
+common ones plus the Root-only props are:
 
 | Prop | Type | Description |
 |------|------|-------------|
@@ -49,9 +52,10 @@ Context provider. Accepts all `UseNumberFieldStateOptions` props plus:
 | `value` / `defaultValue` | `number \| null` | Controlled/uncontrolled value. |
 | `onChange` | `(v: number \| null) => void` | Called whenever the parsed numeric value changes. |
 | `onValueChange` | `(v, details) => void` | Like `onChange`, plus `{ reason, formattedValue }`. |
+| `onValueCommitted` | `(v, details) => void` | Fires only on commit, with `{ reason: "blur" \| "keyboard" }`. |
 | `minValue` / `maxValue` | `number` | Constraints. |
 | `step` / `largeStep` / `smallStep` | `number` | Step sizes. |
-| `validate` | `(v: number \| null) => boolean \| string` | Custom validator. |
+| `validate` | `(v: number \| null) => boolean \| string \| null` | Custom validator. |
 | `disabled` / `readOnly` | `boolean` | Interaction state. |
 | `required` | `boolean` | Marks the field as required. |
 | `allowNegative` / `allowDecimal` | `boolean` | Input constraints. |
@@ -60,6 +64,7 @@ Context provider. Accepts all `UseNumberFieldStateOptions` props plus:
 | `allowMouseWheel` | `boolean` | Enable wheel-based increment/decrement. |
 | `copyBehavior` | `"formatted" \| "raw" \| "number"` | Clipboard behaviour. |
 | `allowOutOfRange` | `boolean` | Skip clamping; show `aria-invalid` instead. |
+| `className` / `style` | `string` / `CSSProperties` | Applied to the root wrapper `<div>`. |
 
 Data attributes set on the root element:
 
@@ -84,7 +89,7 @@ The text input. Accepts all standard `<input>` props except `type` (always `"tex
 
 | Prop | Type | Description |
 |------|------|-------------|
-| `render` | `RenderProp<"input">` | Swap the element (e.g. a styled component). |
+| `render` | `RenderProp` | Swap the element (e.g. a styled component). |
 
 ---
 
@@ -173,12 +178,16 @@ read-only text. Useful for dual-display UIs (edit + display side by side).
 
 ## `NumberField.Description`
 
-Helper text. Automatically wired to `aria-describedby` on the input.
+Renders helper text as a `<p>`. To expose it to screen readers, give your help
+element an `id` and pass it as `aria-describedby` on `<NumberField.Input>` —
+raqam does not link `Description` to the input automatically yet. See
+[Accessibility](/guides/accessibility#associating-help-text).
 
 ```tsx
-<NumberField.Description>
-  Enter a value between 0 and 100.
-</NumberField.Description>
+<NumberField.Root locale="en-US">
+  <NumberField.Input aria-describedby="qty-help" />
+  <p id="qty-help">Enter a value between 0 and 100.</p>
+</NumberField.Root>
 ```
 
 ---

--- a/docs/src/content/docs/api/core-utilities.mdx
+++ b/docs/src/content/docs/api/core-utilities.mdx
@@ -115,10 +115,11 @@ build your own custom input pipeline.
 Returns a `boolean[]` showing which positions in a formatted string are valid
 caret stops.
 
-### `computeNewCursorPosition(oldInput, oldCursor, newFormatted, localeInfo)`
+### `computeNewCursorPosition(oldInput, oldCursor, newFormatted, localeInfo, inputType?)`
 
 Maps the caret from the pre-format string to the new formatted string after an
-edit.
+edit. The optional `inputType` (the native `InputEvent.inputType`, e.g.
+`"deleteContentBackward"`) refines deletion handling around grouping separators.
 
 ```ts
 const formatter = createFormatter({ locale: "en-US" });

--- a/docs/src/content/docs/api/use-number-field-format.mdx
+++ b/docs/src/content/docs/api/use-number-field-format.mdx
@@ -7,6 +7,11 @@ description: Lightweight display-only formatting hook — no input state machine
 It has zero state machine overhead — ideal for price tables, dashboards, or any
 read-only numeric display.
 
+This is a client hook (it ships with the `"use client"` directive). In React
+Server Components, Edge functions, or any non-React code, use `createFormatter`
+from `raqam/server` instead — see [Core utilities](/api/core-utilities) and the
+server-side example below.
+
 ## Import
 
 ```ts
@@ -19,8 +24,8 @@ import { useNumberFieldFormat } from "raqam/react";
 
 ```ts
 function useNumberFieldFormat(
-  value: number | null | undefined,
-  options: {
+  value: number | null,
+  options?: {
     locale?: string;
     formatOptions?: Intl.NumberFormatOptions;
     prefix?: string;
@@ -36,7 +41,7 @@ function useNumberFieldFormat(
 
 | Param | Type | Description |
 |-------|------|-------------|
-| `value` | `number \| null \| undefined` | The value to format. Returns `""` for null/undefined. |
+| `value` | `number \| null` | The value to format. Returns `""` for `null` or non-finite values. |
 | `options.locale` | `string` | BCP 47 locale. Defaults to the current runtime locale. |
 | `options.formatOptions` | `Intl.NumberFormatOptions` | Passed to `Intl.NumberFormat`. |
 | `options.prefix` / `options.suffix` | `string` | Add custom affixes around the formatted value. |
@@ -45,7 +50,7 @@ function useNumberFieldFormat(
 
 ## Return value
 
-A formatted string, or `""` when `value` is null/undefined/NaN.
+A formatted string, or `""` when `value` is `null` or non-finite (`NaN`, `Infinity`).
 
 ## Example — price table
 

--- a/docs/src/content/docs/api/use-number-field-state.mdx
+++ b/docs/src/content/docs/api/use-number-field-state.mdx
@@ -46,8 +46,8 @@ function useNumberFieldState(
 | `minValue` | `number` | — | Minimum allowed value. |
 | `maxValue` | `number` | — | Maximum allowed value. |
 | `step` | `number` | `1` | Normal step (↑/↓ arrow keys). |
-| `largeStep` | `number` | `10` | Large step (Shift+↑/↓, Page Up/Down). |
-| `smallStep` | `number` | `0.1` | Small step (Ctrl/Cmd+↑/↓). |
+| `largeStep` | `number` | `step × 10` | Large step (Shift+↑/↓, Page Up/Down). |
+| `smallStep` | `number` | `step × 0.1` | Small step (Ctrl/Cmd+↑/↓). |
 | `clampBehavior` | `"blur" \| "strict" \| "none"` | `"blur"` | When to clamp to min/max. |
 | `allowOutOfRange` | `boolean` | `false` | Skip clamping; sets `aria-invalid` when out of range. |
 | `allowNegative` | `boolean` | `true` | Allow negative values. |
@@ -68,7 +68,8 @@ function useNumberFieldState(
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `validate` | `(v: number \| null) => boolean \| string \| null` | — | Custom validator. Return `true` for valid, `string` for error message. |
+| `validate` | `(v: number \| null) => boolean \| string \| null \| undefined` | — | Custom validator. Return `true`/`null`/`undefined` for valid, `false` for invalid, or a `string` to set an error message. |
+| `required` | `boolean` | `false` | Mark the field as required (sets `aria-required` / `data-required`). |
 
 ### Escape hatches
 
@@ -82,10 +83,12 @@ function useNumberFieldState(
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `stepHoldDelay` | `number` | `400` | Milliseconds before press-and-hold acceleration starts. |
-| `stepHoldInterval` | `number` | `200` | Milliseconds between accelerated steps. |
 | `disabled` | `boolean` | `false` | Disable all interaction. |
 | `readOnly` | `boolean` | `false` | Allow focus, disallow editing. |
+
+Press-and-hold timing (`stepHoldDelay`, `stepHoldInterval`) and other
+behavior-only props (`copyBehavior`, `allowMouseWheel`, `name`, `label`,
+`aria-*`) live on the behavior hook — see [`useNumberField`](/api/use-number-field).
 
 ## Return value — `NumberFieldState`
 
@@ -100,15 +103,16 @@ function useNumberFieldState(
 | `canDecrement` | `boolean` | False when at `minValue` or `disabled`. |
 | `validationState` | `"valid" \| "invalid"` | Result of the `validate` callback plus range checks. |
 | `validationError` | `string \| null` | Error message from `validate`, or `null`. |
-| `increment()` | `() => void` | Step up by `step`. |
-| `decrement()` | `() => void` | Step down by `step`. |
+| `increment(amount?)` | `(amount?: number) => void` | Step up by `step` (or by `amount` when given). |
+| `decrement(amount?)` | `(amount?: number) => void` | Step down by `step` (or by `amount` when given). |
 | `incrementToMax()` | `() => void` | Jump to `maxValue`. |
 | `decrementToMin()` | `() => void` | Jump to `minValue`. |
-| `setInputValue(s)` | `(s: string) => void` | Directly set the display string. |
+| `setInputValue(s, knownValue?)` | `(s: string, knownValue?: number \| null) => void` | Set the display string. Pass `knownValue` when `s` is a formatted string that can't be reparsed (compact, scientific, unit). |
 | `setNumberValue(n)` | `(n: number \| null) => void` | Directly set the numeric value. |
 | `commit()` | `() => void` | Trigger blur-time formatting and clamping. |
 | `setIsFocused(b)` | `(b: boolean) => void` | Sync focus state (called by `useNumberField`). |
 | `setIsScrubbing(b)` | `(b: boolean) => void` | Sync scrub state (called by `useScrubArea`). |
+| `options` | `UseNumberFieldStateOptions` | The resolved options object (read by `useNumberField`/`useScrubArea`). |
 
 ## Example
 

--- a/docs/src/content/docs/api/use-number-field.mdx
+++ b/docs/src/content/docs/api/use-number-field.mdx
@@ -21,7 +21,7 @@ import { useNumberField } from "raqam/react";
 function useNumberField(
   props: UseNumberFieldProps,
   state: NumberFieldState,
-  inputRef: React.RefObject<HTMLInputElement>
+  inputRef: React.RefObject<HTMLInputElement | null>
 ): NumberFieldAria;
 ```
 
@@ -30,15 +30,20 @@ function useNumberField(
 `UseNumberFieldProps` extends `UseNumberFieldStateOptions` (all state options
 are also accepted here for convenience) plus:
 
-| Prop | Type | Description |
-|------|------|-------------|
-| `id` | `string` | Explicit `id` for the `<input>`. Auto-generated via `useId` if omitted. |
-| `aria-label` | `string` | Accessible label when no visible label is used. |
-| `aria-labelledby` | `string` | Points to an external label element. |
-| `aria-describedby` | `string` | Points to a description element. |
-| `name` | `string` | Enables `hiddenInputProps` for native form submission. |
-| `allowMouseWheel` | `boolean` | Enables wheel-based increment/decrement. |
-| `copyBehavior` | `"formatted" \| "raw" \| "number"` | What goes to the clipboard on Copy/Cut. Default `"formatted"`. |
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `label` | `string` | — | Visible label text; used as the `aria-label` fallback. |
+| `id` | `string` | auto | Explicit `id` for the `<input>`. Auto-generated via `useId` if omitted. |
+| `aria-label` | `string` | — | Accessible label when no visible label is used. |
+| `aria-labelledby` | `string` | — | Points to an external label element. |
+| `aria-describedby` | `string` | — | Points to a description element (set this to wire `<NumberField.Description>` — see [Accessibility](/guides/accessibility)). |
+| `name` | `string` | — | Enables `hiddenInputProps` for native form submission. |
+| `allowMouseWheel` | `boolean` | `false` | Enables wheel-based increment/decrement. |
+| `copyBehavior` | `"formatted" \| "raw" \| "number"` | `"formatted"` | What goes to the clipboard on Copy/Cut. |
+| `stepHoldDelay` | `number` | `400` | Milliseconds before press-and-hold acceleration starts. |
+| `stepHoldInterval` | `number` | `200` | Milliseconds between accelerated steps. |
+| `onFocus` | `(e: React.FocusEvent<HTMLInputElement>) => void` | — | Called when the input gains focus. |
+| `onBlur` | `(e: React.FocusEvent<HTMLInputElement>) => void` | — | Called when the input loses focus (fires after commit). |
 
 All other props from `UseNumberFieldStateOptions` (`minValue`, `maxValue`,
 `step`, `formatOptions`, etc.) are accepted and forwarded appropriately.
@@ -48,13 +53,13 @@ All other props from `UseNumberFieldStateOptions` (`minValue`, `maxValue`,
 | Key | Spread onto | Description |
 |-----|------------|-------------|
 | `labelProps` | `<label>` | `htmlFor` wired to the input `id`. |
-| `groupProps` | wrapping `<div>` | `role="group"`, `aria-disabled`. |
+| `groupProps` | wrapping `<div>` | `role="group"`, `aria-labelledby` pointing at the label. |
 | `inputProps` | `<input>` | Full ARIA spinbutton, keyboard/wheel handlers, cursor logic. |
-| `incrementButtonProps` | increment `<button>` | `aria-label`, `disabled`, press-and-hold. |
-| `decrementButtonProps` | decrement `<button>` | `aria-label`, `disabled`, press-and-hold. |
-| `hiddenInputProps` | `<input type="hidden">` | `value` = the raw number for form submission. |
-| `descriptionProps` | description `<p>` | `id` for `aria-describedby` wiring. |
-| `errorMessageProps` | error `<p>` | `role="alert"`, shown when invalid. |
+| `incrementButtonProps` | increment `<button>` | `aria-label="Increase"`, `disabled`, press-and-hold. |
+| `decrementButtonProps` | decrement `<button>` | `aria-label="Decrease"`, `disabled`, press-and-hold. |
+| `hiddenInputProps` | `<input type="hidden">` | `value` = the raw number for form submission. `null` when no `name` is set. |
+| `descriptionProps` | description `<p>` | A generated `id` you can reference via `aria-describedby` on the input. |
+| `errorMessageProps` | error `<p>` | `role="alert"`, `aria-live="polite"`. Auto-linked via the input's `aria-errormessage` when invalid. |
 
 ## Keyboard behaviour (built-in)
 

--- a/docs/src/content/docs/guides/accessibility.mdx
+++ b/docs/src/content/docs/guides/accessibility.mdx
@@ -19,12 +19,13 @@ manually.
 | `aria-valuemin` | `minValue` | Only set when `minValue` is provided |
 | `aria-valuemax` | `maxValue` | Only set when `maxValue` is provided |
 | `aria-valuetext` | formatted string | Localized display value for screen readers |
-| `aria-invalid` | `"true"` when invalid | Set by `validate` callback or `allowOutOfRange` |
-| `aria-disabled` | `"true"` when disabled | |
-| `aria-readonly` | `"true"` when readOnly | |
-| `aria-required` | `"true"` when required | Pass `required` prop |
+| `aria-invalid` | boolean `true` when invalid | Set by `validate` callback or `allowOutOfRange` |
+| `aria-disabled` | `true` when disabled | |
+| `aria-readonly` | `true` when readOnly | |
+| `aria-required` | `true` when required | Pass `required` prop |
 | `aria-labelledby` | — | Auto-wired from `<NumberField.Label>` |
-| `aria-describedby` | — | Auto-wired from `<NumberField.Description>` |
+| `aria-describedby` | — | Only set when you pass `aria-describedby` on `<NumberField.Input>` — see [Associating help text](#associating-help-text) |
+| `aria-errormessage` | error element `id` | Auto-wired to `<NumberField.ErrorMessage>` when the field is invalid |
 | `inputMode` | `"decimal"` | Surfaces the numeric keyboard on mobile |
 | `type` | `"text"` | Always `text` (not `number`) to avoid browser UI conflicts |
 | `autoComplete` | `"off"` | Prevents autocomplete interference |
@@ -32,7 +33,9 @@ manually.
 ### Button elements
 
 Increment and decrement buttons receive:
-- `aria-label`: `"Increase value"` / `"Decrease value"` (localizable via prop)
+- `aria-label`: `"Increase"` / `"Decrease"`. To translate them, pass your own
+  `aria-label` on `<NumberField.Increment>` / `<NumberField.Decrement>` — it
+  overrides the default.
 - `tabIndex={-1}`: Buttons are intentionally outside the Tab order
 - `disabled`: When at `minValue`/`maxValue` or when the field is disabled
 
@@ -42,9 +45,9 @@ Increment and decrement buttons receive:
 |-----|--------|
 | ↑ | Increment by `step` |
 | ↓ | Decrement by `step` |
-| Shift + ↑ | Increment by `largeStep` (default 10) |
+| Shift + ↑ | Increment by `largeStep` (default `step × 10`) |
 | Shift + ↓ | Decrement by `largeStep` |
-| Ctrl/Cmd + ↑ | Increment by `smallStep` (default 0.1) |
+| Ctrl/Cmd + ↑ | Increment by `smallStep` (default `step × 0.1`) |
 | Ctrl/Cmd + ↓ | Decrement by `smallStep` |
 | Page Up | Increment by `largeStep` |
 | Page Down | Decrement by `largeStep` |
@@ -77,7 +80,23 @@ Use `aria-errormessage` (via `NumberField.ErrorMessage`) to announce errors:
 ```
 
 `NumberField.ErrorMessage` has `role="alert"` which causes screen readers to
-announce the message immediately when it appears.
+announce the message immediately when it appears. The input is automatically
+linked to it via `aria-errormessage` whenever the field is invalid.
+
+## Associating help text
+
+`<NumberField.ErrorMessage>` is wired to the input automatically. **Help text is
+not** — raqam does not yet auto-link `<NumberField.Description>` to the input.
+To describe a field for screen readers, give your help element an `id` and pass
+it as `aria-describedby` on `<NumberField.Input>`:
+
+```tsx
+<NumberField.Root locale="en-US">
+  <NumberField.Label>Quantity</NumberField.Label>
+  <NumberField.Input aria-describedby="qty-help" />
+  <p id="qty-help">Enter a value between 0 and 100.</p>
+</NumberField.Root>
+```
 
 ## Accessible label patterns
 

--- a/docs/src/content/docs/guides/locales.mdx
+++ b/docs/src/content/docs/guides/locales.mdx
@@ -64,12 +64,14 @@ the plugin, `۱۲۳` is accepted and internally treated as `123`.
 import "raqam/locales";   // imports fa, ar, hi, bn, th
 ```
 
-Each plugin is only ~100 bytes gzipped.
+Each plugin is tiny — well under 200 B (e.g. `raqam/locales/fa` is 189 B, min +
+brotli), enforced in CI via `.size-limit.json`.
 
 ### Locale metadata exports
 
-If you want to build locale pickers or feature flags, the bundle entrypoint also
-re-exports the supported locale lists:
+If you want to build locale pickers or feature flags, the `raqam/locales`
+entrypoint also re-exports the supported locale lists (the main `raqam` entry
+does not):
 
 ```ts
 import {
@@ -94,7 +96,8 @@ en-US:  10,000,000  (millions)
 hi-IN:  1,00,00,000 (crores)
 ```
 
-raqam handles this automatically via `Intl.NumberFormat`.
+raqam handles this automatically via `Intl.NumberFormat`. Native digit input for
+Marathi (`mr`) and Nepali (`ne`) ships in the `raqam/locales/hi` plugin.
 
 ## RTL locales
 

--- a/docs/src/content/docs/guides/nextjs.mdx
+++ b/docs/src/content/docs/guides/nextjs.mdx
@@ -39,8 +39,11 @@ export function PriceInput({ value, onChange }: {
 ```
 
 <Aside>
-  The `raqam` package ships with `"use client";` prepended to its bundles.
-  You can import it directly in Client Components without any extra wrapper.
+  The React entries (`raqam` and `raqam/react`) ship with `"use client";`
+  prepended to their bundles, so you can import them directly in Client
+  Components without any extra wrapper. `raqam/core` and `raqam/server` do
+  **not** carry the directive — they have zero React dependency and are safe to
+  import from Server Components.
 </Aside>
 
 ## Server Components — formatting only

--- a/docs/src/content/docs/guides/rtl.mdx
+++ b/docs/src/content/docs/guides/rtl.mdx
@@ -53,6 +53,12 @@ input[data-rtl] {
 }
 ```
 
+<Aside type="note">
+  `data-rtl` is set on the **input** element, not on `NumberField.Root`. Tailwind
+  patterns that key off the root (`group-data-[rtl]`) won't see it — target the
+  input directly (`data-[rtl]:` on `<NumberField.Input>`).
+</Aside>
+
 ## Persian example
 
 ```tsx
@@ -117,4 +123,4 @@ container with `dir="rtl"`:
 All keyboard shortcuts work correctly in RTL mode:
 - ↑/↓ increment/decrement
 - Backspace over grouping separators (e.g. `٬`) skips them correctly
-- Home/End jump to `minValue`/`maxValue`
+- Home/End jump to `minValue`/`maxValue` (when those are set)

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -3,7 +3,7 @@ title: 🔢 Raqam
 description: The definitive React number input — live formatting, full i18n, headless, accessible
 template: splash
 hero:
-  tagline: Live formatting • Full i18n • Headless • Accessible • < 5 KB
+  tagline: Live formatting • Full i18n • Headless • Accessible • ~1.8 KB core
   actions:
     - text: Get Started
       link: /raqam/getting-started
@@ -84,9 +84,11 @@ Type `1234` → see `$1,234.00`. Type `1234.5` → see `$1,234.5` (live, no flic
 
 ## Bundle size
 
-| Import             | Gzipped  |
-| ------------------ | -------- |
-| `raqam/core`       | < 2 KB   |
-| `raqam` (full)     | < 9 KB   |
-| `raqam/locales/fa` | < 0.3 KB |
-| `raqam/locales/ar` | < 0.3 KB |
+Measured min + brotli (including dependencies), enforced in CI:
+
+| Import             | Size     | CI budget |
+| ------------------ | -------- | --------- |
+| `raqam/core`       | ~1.84 KB | 2 KB      |
+| `raqam` (full)     | ~8.3 KB  | 12 KB     |
+| `raqam/react`      | ~8.1 KB  | 10 KB     |
+| `raqam/locales/fa` | 189 B    | 0.3 KB    |

--- a/docs/src/content/docs/recipes/financial.mdx
+++ b/docs/src/content/docs/recipes/financial.mdx
@@ -62,10 +62,14 @@ function CryptoInput() {
       locale="en-US"
       defaultValue={0}
       formatValue={(v) => v.toFixed(8)}
-      parseValue={(s) => ({
-        value: parseFloat(s),
-        isIntermediate: s.endsWith(".") || /\.\d*0+$/.test(s),
-      })}
+      parseValue={(s) => {
+        const n = parseFloat(s);
+        return {
+          // Return null (not NaN) for empty/unparseable input
+          value: s === "" || Number.isNaN(n) ? null : n,
+          isIntermediate: s.endsWith(".") || /\.\d*0+$/.test(s),
+        };
+      }}
       onRawChange={setRaw}
     >
       <NumberField.Label>BTC amount</NumberField.Label>
@@ -157,7 +161,7 @@ Know exactly how the user changed the value — useful for analytics:
   defaultValue={0}
   onValueChange={(value, { reason, formattedValue }) => {
     analytics.track("number_changed", { value, reason, formattedValue });
-    // reason: "keyboard" | "wheel" | "paste" | "blur" | "increment" | "decrement" | "scrub"
+    // reason: "input" | "clear" | "blur" | "paste" | "keyboard" | "increment" | "decrement" | "wheel" | "scrub"
   }}
 >
   <NumberField.Input />

--- a/docs/src/content/docs/recipes/formik.mdx
+++ b/docs/src/content/docs/recipes/formik.mdx
@@ -108,7 +108,7 @@ export function PriceForm() {
         onBlur={() => formik.setFieldTouched("price")}
       >
         <NumberField.Label>Price</NumberField.Label>
-        <NumberField.Input name="price" />
+        <NumberField.Input />
         {formik.touched.price && formik.errors.price && (
           <p style={{ color: "red", fontSize: 12 }}>{formik.errors.price}</p>
         )}

--- a/docs/src/content/docs/recipes/persian-ecommerce.mdx
+++ b/docs/src/content/docs/recipes/persian-ecommerce.mdx
@@ -36,7 +36,7 @@ export function TomanInput() {
       <NumberField.Label>قیمت</NumberField.Label>  {/* "Price" */}
       <NumberField.Group>
         <NumberField.Decrement>−</NumberField.Decrement>
-        <NumberField.Input dir="ltr" />  {/* raqam sets dir="ltr" internally */}
+        <NumberField.Input />  {/* raqam applies direction: ltr automatically for RTL locales */}
         <NumberField.Increment>+</NumberField.Increment>
       </NumberField.Group>
     </NumberField.Root>
@@ -73,9 +73,13 @@ export function ProductPriceEditor() {
         <NumberField.Label style={{ display: "block", marginBottom: 4 }}>
           قیمت محصول
         </NumberField.Label>
-        <NumberField.Group style={{ display: "flex", direction: "ltr" }}>
+        <NumberField.Group style={{ display: "flex" }}>
           <NumberField.Decrement>−</NumberField.Decrement>
-          <NumberField.Input style={{ flex: 1, textAlign: "right", padding: "6px 10px" }} />
+          {/* An inline `style` replaces raqam's RTL style object, so re-declare
+              direction: ltr here (or style the input with className instead). */}
+          <NumberField.Input
+            style={{ flex: 1, padding: "6px 10px", direction: "ltr", textAlign: "right" }}
+          />
           <NumberField.Increment>+</NumberField.Increment>
         </NumberField.Group>
         <NumberField.ErrorMessage style={{ color: "red", fontSize: 12 }} />
@@ -101,7 +105,7 @@ Persian digit normalization is transparent:
 
 ## IRR currency format
 
-If you want the `ریال` symbol from `Intl.NumberFormat`:
+If you want the official rial currency symbol from `Intl.NumberFormat`:
 
 ```tsx
 <NumberField.Root
@@ -111,7 +115,9 @@ If you want the `ریال` symbol from `Intl.NumberFormat`:
 >
   <NumberField.Input />
 </NumberField.Root>
-// Displays: ۰٫۰۰ ﷼
+// Displays something like: ۰ ﷼
+// The exact symbol (﷼ vs ریال) and number of fraction digits come from the
+// runtime's ICU data, so output can vary across environments.
 ```
 
 ## Validation for price ranges

--- a/docs/src/content/docs/recipes/shadcn-ui.mdx
+++ b/docs/src/content/docs/recipes/shadcn-ui.mdx
@@ -20,10 +20,11 @@ Create a reusable `RaqamInput` component that follows the shadcn design language
 import * as React from "react";
 import { NumberField } from "raqam";
 import { cn } from "@/lib/utils";
-import type { UseNumberFieldStateOptions } from "raqam";
+import type { UseNumberFieldProps } from "raqam";
 
-interface RaqamInputProps extends UseNumberFieldStateOptions {
-  label?: string;
+// UseNumberFieldProps includes every state option plus behavior props
+// (label, name, aria-*, copyBehavior, …), so name/aria pass-through type-checks.
+interface RaqamInputProps extends UseNumberFieldProps {
   description?: string;
   className?: string;
 }

--- a/docs/src/content/docs/recipes/tailwind.mdx
+++ b/docs/src/content/docs/recipes/tailwind.mdx
@@ -78,6 +78,12 @@ Available data attributes on the root:
 | `data-invalid` | Value is invalid |
 | `data-disabled` | `disabled={true}` |
 | `data-readonly` | `readOnly={true}` |
+| `data-required` | `required={true}` |
+| `data-scrubbing` | A scrub drag is in progress |
+
+The **input** element also carries `data-invalid`, `data-disabled`,
+`data-readonly`, `data-required`, and `data-rtl`, so you can style it directly
+(e.g. `data-[invalid]:border-red-500` on `<NumberField.Input>`).
 
 ## Dark mode
 
@@ -124,8 +130,8 @@ Available data attributes on the root:
     className={[
       "px-3 py-2 border rounded-md text-sm outline-none",
       "border-gray-300 focus:ring-2 focus:ring-blue-400",
-      // Tailwind can't dynamically check data-invalid on the input,
-      // so use the validate prop + ErrorMessage instead:
+      // The input carries data-invalid, so you can style it directly:
+      "data-[invalid]:border-red-500 data-[invalid]:ring-red-400",
     ].join(" ")}
   />
   <NumberField.ErrorMessage className="text-xs text-red-600" />


### PR DESCRIPTION
## Summary

Documentation-only overhaul. Every doc was audited against the actual source and
corrected for **accuracy**, **duplication**, and **developer experience**. No
runtime/source behavior changed.

**Accuracy fixes (doc claimed ≠ code did):**
- **Bundle sizes** were wrong and inconsistent across files. Measured the real
  CI-enforced numbers (min + brotli, incl. deps) and made them identical in
  `README.md`, `docs/index.mdx`, and `CHANGELOG.md`:
  core ~1.84 KB · react ~8.1 KB · full ~8.3 KB · `locales/fa` 189 B.
- **`CONTRIBUTING.md`**: the `registerLocale` snippet used the wrong shape
  (`{ digits: [...] }`) — fixed to `{ digitBlocks: [[start, end]] }` and aligned
  the locale-plugin guide with the real `fa.ts` pattern (`LOCALE_CODES`, tsup entry).
- **API docs**: corrected option ownership (state hook vs behavior hook — e.g.
  `stepHoldDelay`/`stepHoldInterval` belong to `useNumberField`), `largeStep`/
  `smallStep` defaults (`step × 10` / `step × 0.1`), `setInputValue`/`increment`
  signatures, `RenderProp` type, `computeNewCursorPosition`'s `inputType` param,
  and clarified that `useNumberFieldFormat` is client-only (use `createFormatter`
  from `raqam/server` in RSC).
- **Guides/recipes**: real stepper `aria-label`s (`"Increase"`/`"Decrease"`),
  complete `data-*` list (incl. `data-required`/`data-scrubbing`; `data-rtl` is on
  the **input**), accurate `"use client"` scope, the inline-`style`-clobbers-RTL
  caveat, a `parseValue` null-guard, and the full `ChangeReason` union.
- **`DEFINITION.md`**: framed as a **historical design spec** (banner) and fixed
  in-place errors (`raqam/components` → `raqam`, `min`/`max` → `minValue`/`maxValue`).
- Playground Sandpack pinned to **0.2.4**.

**De-duplication:** README is the curated front door that links to the docs site
for the full reference; the docs site is the single canonical API reference;
skills already link out (verified accurate, unchanged).

## Reviewer notes

- This PR is **docs-only** — no `src/` changes.
- Two genuine *source* bugs were discovered and intentionally **left for separate
  PRs** (out of scope here); the docs now describe current behavior accurately:
  1. `<NumberField.Description>` is never wired into the input's `aria-describedby`
     (a `descriptionId` is computed but unused).
  2. Stepper `aria-label`s are hardcoded English (only overridable via `aria-label`
     on the component).
- Branch was rebased onto current `main` (v0.2.4); `CHANGELOG.md` auto-merged
  cleanly (release entry on top + the corrected historical bundle table).

## Checklist

- [x] Tests added or updated for new behavior — N/A (docs only, no behavior change)
- [x] `pnpm test` passes locally — 598/598 across 26 files
- [x] `pnpm typecheck` passes (0 errors)
- [x] `pnpm lint` passes (Biome) — exit 0 (pre-existing `src/` warnings only)
- [x] Changeset added (`pnpm changeset`) for any user-facing changes — patch
- [x] Docs updated if the public API changed — this PR *is* the docs update
- [x] Stories added/updated in Storybook for UI changes — N/A (no UI changes)
- [x] Docs site builds (`astro build`) — 21 pages

## Related issues

Closes #
