### PR TITLE
fix: avoid dangling aria-labelledby when only aria-label is set

### DIFF
--- a/.changeset/fix-dangling-aria-labelledby.md
+++ b/.changeset/fix-dangling-aria-labelledby.md
@@ -1,0 +1,12 @@
+---
+"raqam": patch
+---
+
+Fix dangling `aria-labelledby` when only `aria-label` is provided
+
+`useNumberField` previously defaulted the input's (and group's) `aria-labelledby`
+to `${id}-label` unconditionally, pointing at a `<label>` the consumer may never
+render. When you pass `aria-label` instead of rendering a label, this produced a
+reference to a non-existent id (the "aria-labelledby attribute doesn't match any
+element id" warning) and broke the field's accessible name. The fallback now only
+applies when no `aria-label`/`aria-labelledby` is supplied.

--- a/src/react/NumberField.test.tsx
+++ b/src/react/NumberField.test.tsx
@@ -30,6 +30,8 @@ describe("NumberField.Root", () => {
     expect(label).toBeInTheDocument();
     // Label should point to input via htmlFor
     expect(label.getAttribute("for")).toBe(input.getAttribute("id"));
+    // ...and the input's aria-labelledby must point back at a real label id
+    expect(input.getAttribute("aria-labelledby")).toBe(label.getAttribute("id"));
   });
 
   it("renders increment and decrement buttons", () => {

--- a/src/react/useNumberField.test.tsx
+++ b/src/react/useNumberField.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useRef } from "react";
+import { useNumberField } from "./useNumberField.js";
+import { useNumberFieldState } from "./useNumberFieldState.js";
+import type { UseNumberFieldProps } from "../core/types.js";
+
+// Wires the headless hooks together exactly like a consumer building their own
+// markup would (the API surface that doesn't go through <NumberField.Root>).
+function renderAria(props: UseNumberFieldProps) {
+  return renderHook(() => {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const state = useNumberFieldState(props);
+    return useNumberField(props, state, inputRef);
+  });
+}
+
+describe("useNumberField — aria-labelledby resolution", () => {
+  it("omits aria-labelledby when only aria-label is provided (no dangling ref)", () => {
+    // Regression: previously aria-labelledby always defaulted to `${id}-label`,
+    // pointing at a <label> the consumer never rendered. With an aria-label and
+    // no rendered label, aria-labelledby must not be set.
+    const { result } = renderAria({ locale: "en-US", "aria-label": "Amount" });
+    expect(result.current.inputProps["aria-label"]).toBe("Amount");
+    expect(result.current.inputProps["aria-labelledby"]).toBeUndefined();
+    expect(result.current.groupProps["aria-labelledby"]).toBeUndefined();
+  });
+
+  it("falls back to the internal label id when no accessible name is provided", () => {
+    const { result } = renderAria({ locale: "en-US", id: "amount" });
+    // The fallback points at the label element the consumer is expected to
+    // render via labelProps — labelProps.id matches, so the ref is not dangling.
+    expect(result.current.inputProps["aria-labelledby"]).toBe("amount-label");
+    expect(result.current.labelProps.id).toBe("amount-label");
+    expect(result.current.inputProps["aria-labelledby"]).toBe(
+      result.current.labelProps.id
+    );
+  });
+
+  it("respects an explicit aria-labelledby over the fallback and aria-label", () => {
+    const { result } = renderAria({
+      locale: "en-US",
+      "aria-label": "Amount",
+      "aria-labelledby": "external-label",
+    });
+    expect(result.current.inputProps["aria-labelledby"]).toBe("external-label");
+    expect(result.current.groupProps["aria-labelledby"]).toBe("external-label");
+  });
+});

--- a/src/react/useNumberField.ts
+++ b/src/react/useNumberField.ts
@@ -806,6 +806,12 @@ export function useNumberField(
 
   // ── Prop maps ────────────────────────────────────────────────────────────
 
+  // Only fall back to the internal label id when the consumer hasn't supplied
+  // their own accessible name. Defaulting to `labelId` unconditionally points
+  // `aria-labelledby` at a `<label>` the consumer may never render (e.g. when
+  // they pass `aria-label` instead), producing a dangling reference.
+  const ariaLabelledBy = props["aria-labelledby"] ?? (props["aria-label"] ? undefined : labelId);
+
   const labelProps: React.LabelHTMLAttributes<HTMLLabelElement> = {
     id: labelId,
     htmlFor: inputId,
@@ -813,7 +819,7 @@ export function useNumberField(
 
   const groupProps: React.HTMLAttributes<HTMLDivElement> = {
     role: "group",
-    "aria-labelledby": props["aria-labelledby"] ?? labelId,
+    "aria-labelledby": ariaLabelledBy,
   };
 
   const inputProps: React.InputHTMLAttributes<HTMLInputElement> = {
@@ -825,7 +831,7 @@ export function useNumberField(
     autoCorrect: "off",
     spellCheck: false,
     "aria-label": props["aria-label"],
-    "aria-labelledby": props["aria-labelledby"] ?? labelId,
+    "aria-labelledby": ariaLabelledBy,
     "aria-describedby": props["aria-describedby"],
     "aria-valuenow": state.numberValue ?? undefined,
     "aria-valuemin": minValue,


### PR DESCRIPTION
## Problem

Using raqam's headless `useNumberField` with an `aria-label` (and no rendered `<label>`) emitted the DevTools warning:

> An aria-labelledby attribute doesn't match any element id

`useNumberField` defaulted both the input's and group's `aria-labelledby` to `` `${id}-label` `` **unconditionally**, pointing at a `<label>` the consumer may never render. When you pass `aria-label` instead, this produced a reference to a non-existent id — and because `aria-labelledby` wins over `aria-label`, it also broke the field's accessible name.

## Fix

`aria-labelledby` now only falls back to the internal label id when no accessible name is supplied:

```ts
const ariaLabelledBy =
  props["aria-labelledby"] ?? (props["aria-label"] ? undefined : labelId);
```

- `aria-label` only → no `aria-labelledby` (no dangling ref) ✅
- `<NumberField.Label>` rendered → still references `labelId` ✅
- explicit `aria-labelledby` → respected ✅

## Tests

- `src/react/useNumberField.test.tsx` — new hook-level regression tests for all three paths.
- `src/react/NumberField.test.tsx` — asserts the rendered-label path keeps `aria-labelledby` pointing at a real label id.

`vitest run` → **601 passed, 0 failed**. `tsc --noEmit` clean. Patch changeset included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)