### PR TITLE
Overhaul docs site & raqam skill; wire up onValueCommitted + clear reason

### DIFF
--- a/.changeset/wire-on-value-committed.md
+++ b/.changeset/wire-on-value-committed.md
@@ -1,0 +1,18 @@
+---
+"raqam": minor
+---
+
+Wire up `onValueCommitted` and the `"clear"` change reason
+
+`onValueCommitted` was part of the public type and documented, but `NumberField.Root`
+never actually called it. It now fires once the value is committed — on blur
+(`reason: "blur"`) and when the user presses Enter (`reason: "keyboard"`) — after
+formatting and clamping have been applied, and receives the final settled value.
+It is now also accepted on the `useNumberField` hook (via `UseNumberFieldProps`),
+not just the component API.
+
+The `"clear"` `ChangeReason` is now emitted when an edit empties the field, so
+`onValueChange` consumers can distinguish a deletion-to-empty from ordinary typing.
+
+`NumberFieldState.commit()` now returns the committed numeric value (`number | null`)
+instead of `void`.

--- a/README.md
+++ b/README.md
@@ -39,15 +39,18 @@ import { useNumberFieldState, useNumberField } from 'raqam'
 import { useRef } from 'react'
 
 function PriceInput() {
-  const state = useNumberFieldState({
+  // Share one options object — useNumberField builds its own formatter/parser,
+  // so it needs the same formatting options as useNumberFieldState.
+  const options = {
     locale: 'en-US',
     formatOptions: { style: 'currency', currency: 'USD' },
     minValue: 0,
     defaultValue: 1234.56,
-  })
+  }
+  const state = useNumberFieldState(options)
   const inputRef = useRef(null)
   const { inputProps, labelProps, incrementButtonProps, decrementButtonProps } =
-    useNumberField({ label: 'Price' }, state, inputRef)
+    useNumberField({ ...options, label: 'Price' }, state, inputRef)
 
   return (
     <div>

--- a/README.md
+++ b/README.md
@@ -35,18 +35,19 @@ pnpm add raqam
 ### Hook API
 
 ```tsx
-import { useNumberFieldState, useNumberField } from 'raqam'
+import { useNumberFieldState, useNumberField, type UseNumberFieldStateOptions } from 'raqam'
 import { useRef } from 'react'
 
 function PriceInput() {
   // Share one options object — useNumberField builds its own formatter/parser,
-  // so it needs the same formatting options as useNumberFieldState.
+  // so it needs the same formatting options as useNumberFieldState. `satisfies`
+  // keeps the literal types (e.g. style: 'currency') in a strict TS project.
   const options = {
     locale: 'en-US',
     formatOptions: { style: 'currency', currency: 'USD' },
     minValue: 0,
     defaultValue: 1234.56,
-  }
+  } satisfies UseNumberFieldStateOptions
   const state = useNumberFieldState(options)
   const inputRef = useRef(null)
   const { inputProps, labelProps, incrementButtonProps, decrementButtonProps } =

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -51,6 +51,7 @@ export default defineConfig({
         {
           label: "Guides",
           items: [
+            { label: "Formatting & Behavior", link: "/guides/formatting" },
             { label: "Locales & i18n", link: "/guides/locales" },
             { label: "RTL Support", link: "/guides/rtl" },
             { label: "Next.js App Router", link: "/guides/nextjs" },

--- a/docs/src/content/docs/api/components.mdx
+++ b/docs/src/content/docs/api/components.mdx
@@ -77,9 +77,26 @@ Data attributes set on the root element:
 | `data-required` | `required` is `true` |
 | `data-scrubbing` | A scrub interaction is active |
 
-If you only care about commit-time analytics, use `onValueChange` and check the
-`reason` field (`"blur"`, `"keyboard"`, `"increment"`, `"decrement"`, `"wheel"`,
-`"paste"`, `"input"`, `"clear"`, or `"scrub"`).
+`onValueChange` fires on **every** change and reports how it happened via
+`reason` (`"input"`, `"clear"`, `"paste"`, `"keyboard"`, `"increment"`,
+`"decrement"`, `"wheel"`, `"scrub"`, or `"blur"`). `onValueCommitted` fires
+**only when the value settles** — on blur (`reason: "blur"`) or when the user
+presses Enter (`reason: "keyboard"`) — after formatting and clamping, and
+receives the final value. Use it to persist a value or fire a request without
+reacting to every keystroke.
+
+```tsx
+<NumberField.Root
+  locale="en-US"
+  minValue={0}
+  onValueCommitted={(value, { reason }) => save(value)} // reason: "blur" | "keyboard"
+>
+  <NumberField.Input />
+</NumberField.Root>
+```
+
+See [Formatting & Behavior → Change reasons](/guides/formatting#change-reasons)
+for the full breakdown.
 
 ---
 
@@ -144,7 +161,10 @@ Wraps any element; dragging over it adjusts the value via Pointer Lock API.
 </NumberField.ScrubArea>
 ```
 
-`data-scrubbing` is set on the element while dragging.
+The element renders as `role="slider"` with `tabIndex={0}`, so it is keyboard
+accessible: arrow keys (←/→ or ↑/↓) step the value while it is focused. The CSS
+`cursor` reflects the axis (`ew-resize` / `ns-resize` / `move`), and
+`data-scrubbing=""` is set while a pointer-lock drag is active.
 
 ---
 
@@ -167,12 +187,18 @@ next to the active scrub handle. Accepts `<span>` props.
 ## `NumberField.Formatted`
 
 A `<span>` (or custom element) that displays the current formatted value as
-read-only text. Useful for dual-display UIs (edit + display side by side).
+read-only text. Useful for dual-display UIs (edit + display side by side). It
+renders with `aria-hidden="true"` so screen readers announce the value once
+(from the input), not twice.
 
 ```tsx
 <NumberField.Formatted />
 {/* Renders: "$1,234.56" */}
 ```
+
+This mirrors `state.inputValue` and updates live as the user edits. For
+formatting outside a `NumberField.Root`, use
+[`useNumberFieldFormat`](/api/use-number-field-format) instead.
 
 ---
 

--- a/docs/src/content/docs/api/core-utilities.mdx
+++ b/docs/src/content/docs/api/core-utilities.mdx
@@ -129,6 +129,37 @@ computeNewCursorPosition("1234", 4, "1,234", info);
 // 5
 ```
 
+## Result types
+
+The formatter and parser return these shapes (all exported as types from
+`raqam`, `raqam/core`, and `raqam/server`):
+
+```ts
+interface LocaleInfo {
+  decimalSeparator: string;   // "." en-US, "," de-DE, "٫" fa-IR
+  groupingSeparator: string;  // "," en-US, "." de-DE, "٬" fa-IR
+  minusSign: string;          // usually "-", but locale-specific
+  zero: string;               // "0" Latin, "۰" Persian, …
+  isRTL: boolean;             // true for ar/he/fa/ur/…
+}
+
+interface ParseResult {
+  value: number | null;       // parsed number, or null if empty/invalid
+  isValid: boolean;           // true for a complete, valid number
+  isIntermediate: boolean;    // valid-but-incomplete ("1.", "1.50", "-")
+}
+
+interface FormatResult {
+  formatted: string;          // the full formatted string
+  parts: Intl.NumberFormatPart[];
+}
+
+type CaretBoundary = boolean[]; // length = formatted.length + 1
+```
+
+`isIntermediate` is what powers live formatting — see
+[Formatting & Behavior → Intermediate states](/guides/formatting#intermediate-states).
+
 ## Presets from the core entrypoint
 
 `presets` is also available from `raqam/core` and `raqam/server`, so you can

--- a/docs/src/content/docs/api/presets.mdx
+++ b/docs/src/content/docs/api/presets.mdx
@@ -144,6 +144,21 @@ presets.unit("kilometer")
 Unit formatting. Any CLDR unit identifier works: `"kilometer"`,
 `"liter"`, `"celsius"`, `"kilometer-per-hour"`, etc.
 
+## Notation presets format on blur
+
+`compact`, `compactLong`, `scientific`, and `engineering` produce strings
+(`1.2K`, `1.23E4`) whose characters collide with continued typing, so raqam
+keeps your raw digits live while editing and only applies the notation on blur.
+This is automatic — you don't need to set `liveFormat`. See
+[Formatting & Behavior → Notation](/guides/formatting#notation-that-formats-on-blur).
+
+`percent` stores the **fraction**: a displayed `42%` is a value of `0.42`, and
+typing `50` yields `0.5`.
+
+`financial` already sets `minimumFractionDigits`/`maximumFractionDigits` to 2, so
+it shows two decimals on its own. Adding the `fixedDecimalScale` prop keeps the
+two trailing zeros locked in even as the user edits.
+
 ## Composing with your own options
 
 Presets are plain objects — spread them to override:

--- a/docs/src/content/docs/api/use-number-field-state.mdx
+++ b/docs/src/content/docs/api/use-number-field-state.mdx
@@ -48,10 +48,13 @@ function useNumberFieldState(
 | `step` | `number` | `1` | Normal step (↑/↓ arrow keys). |
 | `largeStep` | `number` | `step × 10` | Large step (Shift+↑/↓, Page Up/Down). |
 | `smallStep` | `number` | `step × 0.1` | Small step (Ctrl/Cmd+↑/↓). |
-| `clampBehavior` | `"blur" \| "strict" \| "none"` | `"blur"` | When to clamp to min/max. |
-| `allowOutOfRange` | `boolean` | `false` | Skip clamping; sets `aria-invalid` when out of range. |
+| `clampBehavior` | `"blur" \| "strict" \| "none"` | `"blur"` | When to clamp to min/max — clamp on blur, reject out-of-range keystrokes, or never. |
+| `allowOutOfRange` | `boolean` | `false` | Keep out-of-range values as typed and committed; sets `aria-invalid` instead of clamping. |
 | `allowNegative` | `boolean` | `true` | Allow negative values. |
 | `allowDecimal` | `boolean` | `true` | Allow decimal input. |
+
+See [Formatting & Behavior → Clamping](/guides/formatting#clamping--ranges) for
+how `clampBehavior` and `allowOutOfRange` interact.
 
 ### Formatting
 
@@ -59,7 +62,7 @@ function useNumberFieldState(
 |------|------|---------|-------------|
 | `maximumFractionDigits` | `number` | — | Override `formatOptions.maximumFractionDigits`. |
 | `minimumFractionDigits` | `number` | — | Override `formatOptions.minimumFractionDigits`. |
-| `fixedDecimalScale` | `boolean` | `false` | Always show `maximumFractionDigits` decimal places. |
+| `fixedDecimalScale` | `boolean` | `false` | Always show `maximumFractionDigits` decimal places. Requires `maximumFractionDigits` (explicit or from the format) to take effect. |
 | `prefix` | `string` | — | Prepend a string (e.g. `"$"`). |
 | `suffix` | `string` | — | Append a string (e.g. `" kg"`). |
 | `liveFormat` | `boolean` | `true` | Format on every keystroke (disable for IME locales). |
@@ -109,7 +112,7 @@ behavior-only props (`copyBehavior`, `allowMouseWheel`, `name`, `label`,
 | `decrementToMin()` | `() => void` | Jump to `minValue`. |
 | `setInputValue(s, knownValue?)` | `(s: string, knownValue?: number \| null) => void` | Set the display string. Pass `knownValue` when `s` is a formatted string that can't be reparsed (compact, scientific, unit). |
 | `setNumberValue(n)` | `(n: number \| null) => void` | Directly set the numeric value. |
-| `commit()` | `() => void` | Trigger blur-time formatting and clamping. |
+| `commit()` | `() => number \| null` | Trigger blur-time formatting and clamping; returns the committed value. |
 | `setIsFocused(b)` | `(b: boolean) => void` | Sync focus state (called by `useNumberField`). |
 | `setIsScrubbing(b)` | `(b: boolean) => void` | Sync scrub state (called by `useScrubArea`). |
 | `options` | `UseNumberFieldStateOptions` | The resolved options object (read by `useNumberField`/`useScrubArea`). |

--- a/docs/src/content/docs/api/use-number-field.mdx
+++ b/docs/src/content/docs/api/use-number-field.mdx
@@ -44,9 +44,17 @@ are also accepted here for convenience) plus:
 | `stepHoldInterval` | `number` | `200` | Milliseconds between accelerated steps. |
 | `onFocus` | `(e: React.FocusEvent<HTMLInputElement>) => void` | — | Called when the input gains focus. |
 | `onBlur` | `(e: React.FocusEvent<HTMLInputElement>) => void` | — | Called when the input loses focus (fires after commit). |
+| `onValueCommitted` | `(value, { reason }) => void` | — | Fires when the value settles — on blur (`reason: "blur"`) or Enter (`reason: "keyboard"`), after formatting + clamping. |
 
 All other props from `UseNumberFieldStateOptions` (`minValue`, `maxValue`,
 `step`, `formatOptions`, etc.) are accepted and forwarded appropriately.
+
+> **Pass the same options to both hooks.** `useNumberField` builds its own
+> formatter and parser, so it needs the same formatting-relevant options you gave
+> `useNumberFieldState` (`locale`, `formatOptions`, `prefix`, `suffix`,
+> `minValue`/`maxValue`, `allowNegative`, `allowDecimal`, fraction-digit
+> overrides). Share one options object between them. The
+> [`NumberField` components](/api/components) handle this wiring for you.
 
 ## Return value — `NumberFieldAria`
 
@@ -73,8 +81,12 @@ All other props from `UseNumberFieldStateOptions` (`minValue`, `maxValue`,
 | Page Down | Decrement by `largeStep` |
 | Home | Jump to `minValue` |
 | End | Jump to `maxValue` |
-| Enter | Commit current value |
-| Backspace | Smart deletion (skips over grouping separators) |
+| Enter | Commit the current value (fires `onValueCommitted`) |
+| Backspace | Smart deletion (deletes through grouping separators and trailing affordances) |
+
+`Home`/`End` only act when `minValue`/`maxValue` are set. For the full story on
+smart backspace, the smart-decimal caret jump, paste handling, and live
+formatting, see [Formatting & Behavior](/guides/formatting).
 
 The returned `inputProps` also include `data-rtl`, `data-invalid`,
 `data-disabled`, `data-readonly`, and `data-required` attributes so you can

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -61,14 +61,13 @@ import { useNumberFieldState, useNumberField } from "raqam";
 export function QuantityInput() {
   const inputRef = useRef<HTMLInputElement>(null);
 
-  const state = useNumberFieldState({
-    locale: "en-US",
-    defaultValue: 1,
-    minValue: 0,
-  });
+  // Share one options object — useNumberField builds its own formatter/parser
+  // and needs the same formatting-relevant options as the state hook.
+  const options = { locale: "en-US", defaultValue: 1, minValue: 0 };
 
+  const state = useNumberFieldState(options);
   const { labelProps, groupProps, inputProps, incrementButtonProps, decrementButtonProps } =
-    useNumberField({ locale: "en-US", minValue: 0 }, state, inputRef);
+    useNumberField(options, state, inputRef);
 
   return (
     <div>
@@ -82,6 +81,10 @@ export function QuantityInput() {
   );
 }
 ```
+
+The `NumberField` components do this wiring for you, so reach for the Hook API
+only when you need full control of the DOM. See
+[`useNumberField`](/api/use-number-field) for why both hooks need the same options.
 
 ## Controlled vs uncontrolled
 
@@ -107,7 +110,9 @@ const [value, setValue] = useState<number | null>(42);
 
 `onChange` receives `number | null` whenever the parsed numeric value changes.
 If you need metadata about *how* the change happened, use `onValueChange` on
-`NumberField.Root` for `{ reason, formattedValue }`.
+`NumberField.Root` for `{ reason, formattedValue }`. To react only when the value
+settles (on blur or Enter), use `onValueCommitted` instead — see
+[Formatting & Behavior → Change reasons](/guides/formatting#change-reasons).
 
 ## Currency formatting
 

--- a/docs/src/content/docs/guides/formatting.mdx
+++ b/docs/src/content/docs/guides/formatting.mdx
@@ -1,0 +1,227 @@
+---
+title: Formatting & Input Behavior
+description: How raqam formats while you type — the cursor algorithm, intermediate states, paste/copy, smart editing, clamping, and notation handling.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+This page explains what actually happens between a keystroke and the formatted
+value you see. raqam's headline feature is **live, cursor-safe formatting**:
+the field reformats on every keystroke without the caret ever jumping to the
+wrong place or the value being corrupted mid-edit.
+
+## The typing pipeline
+
+On every `input` event the field runs the same sequence:
+
+1. **Normalize digits** — non-Latin digits (Persian `۱۲۳`, Arabic `١٢٣`, …) are
+   mapped to ASCII via the registered [locale plugins](/guides/locales).
+2. **Apply constraints** — characters disallowed by `allowNegative` /
+   `allowDecimal` are dropped *as you type*, so the field never shows a string
+   that gets wiped on blur. A stray `-` or `.` simply does nothing.
+3. **Parse** with the locale-aware parser (separators are read from
+   `Intl.NumberFormat`, never hardcoded).
+4. **Reformat** — a valid, *complete* value is re-rendered with grouping; an
+   *intermediate* value (see below) is kept exactly as typed.
+5. **Restore the caret** — the new caret position is computed from the old
+   string, old caret, and new formatted string, then restored synchronously
+   after React commits, so the cursor stays put even as separators shift.
+
+The caret math is exposed for custom pipelines as
+[`getCaretBoundary` and `computeNewCursorPosition`](/api/core-utilities#caret-helpers).
+
+## Intermediate states
+
+Some inputs are *valid but incomplete* — reformatting them mid-typing would
+fight the user. raqam detects these and leaves the display untouched (while
+still updating the numeric value) until you commit:
+
+| You type | Display stays | `numberValue` |
+|----------|---------------|---------------|
+| `1.` | `1.` | `1` |
+| `1.0` | `1.0` | `1` |
+| `12.50` | `12.50` | `12.5` |
+| `.5` | `.5` | `0.5` |
+| `-` | `-` | `null` |
+| `-0` | `-0` | `0` |
+
+On blur (commit) these snap to the canonical formatted form (`1`, `12.50` →
+`12.5` if the format allows, `.5` → `0.5`, a lone `-` → empty). The integer part
+still groups live even while a trailing decimal is in progress — inserting digits
+into `$12.50` correctly shows `$9,912.50`.
+
+<Aside type="tip">
+  Need the *exact* string the user typed (trailing zeros and all) before any
+  float conversion? Read `state.rawValue` or pass `onRawChange`. See
+  [Financial patterns](/recipes/financial#arbitrary-precision-crypto--scientific).
+</Aside>
+
+## Notation that formats on blur
+
+Compact (`2.5K`), scientific (`1.23E4`), and engineering notation produce
+strings whose suffix/exponent characters collide with continued typing. For
+these `formatOptions.notation` values raqam **keeps your raw digits live and only
+formats on blur/commit** — `liveFormat` is effectively forced off:
+
+```tsx
+<NumberField.Root formatOptions={{ notation: "compact" }} defaultValue={1500} />
+// Shows "1.5K". Focus + type "2500" → you see raw "2500" → blur → "2.5K".
+```
+
+Because these formats are not reversible by re-parsing, raqam tracks the exact
+numeric value internally rather than reading it back from the display.
+
+## Percent fields
+
+A percent field stores the **fraction** — `Intl.NumberFormat` multiplies by 100
+on display — so typing `50` means `50%`, i.e. a value of `0.5`:
+
+```tsx
+<NumberField.Root formatOptions={{ style: "percent" }} defaultValue={0.42} />
+// Displays "42%". onChange fires with 0.42, not 42.
+```
+
+While typing, the live formatter is given extra fraction headroom so a value
+like `12.5%` is never rounded out from under your cursor; `commit()` rounds to
+the format's configured scale on blur.
+
+## Decimal separator handling
+
+raqam reads the locale's decimal and grouping separators from
+`Intl.NumberFormat`. Two conveniences smooth over keyboard differences:
+
+- **Latin keyboards in non-Latin locales** — in `ar`/`fa` (decimal separator
+  `٫`) a typed ASCII `.` that sits between digits is mapped onto the locale
+  separator, so the value parses and the caret stays correct. A `.` inside a
+  currency symbol (e.g. Arabic `ج.م.`) is left alone.
+- **`.` as a grouping separator** (e.g. `de-DE` → `1.234,56`) — the ASCII `.`
+  is treated as grouping, not decimal, and the comma is the decimal key.
+
+## Smart editing
+
+### Smart backspace
+
+Two cases the browser would otherwise mishandle:
+
+- **Grouping separators** — pressing Backspace right after a thousands separator
+  deletes the separator *and* the digit before it, then re-groups. You can
+  backspace through `1,234,567` without the comma "blocking" deletion.
+- **Trailing affordances** — Backspace at the end of `50%` or `12 kg` deletes the
+  last *digit* (the `%`/suffix would otherwise be instantly re-appended, making
+  the keypress appear to do nothing).
+
+### Smart decimal
+
+Typing the decimal separator when one already exists doesn't insert a duplicate
+— it moves the caret to just after the existing separator. This drives the
+fixed-scale money pattern:
+
+```
+"1.00"  →  press "."  →  caret jumps after the "."  →  type "5"  →  "1.50"
+```
+
+## Paste
+
+Pasting is more permissive than typing, so values copied from spreadsheets and
+dashboards round-trip. On paste raqam, in order:
+
+1. Strips common currency symbols (`$ € £ ¥ ₹ ₺ ₽ ﷼ ฿ ₩ ¢ ₦ ₨ ₪ ₫ ₱`).
+2. Normalizes non-Latin digits.
+3. Honors `allowNegative` / `allowDecimal`.
+4. Parses **scientific / compact** notation (`1e3`, `1.23E4`, `1.5K`, `3.4M`,
+   `2 billion`).
+5. Parses **accounting** parentheses — `(1,234.56)` becomes `-1234.56`.
+6. Falls back to stripping everything except digits, the locale decimal
+   separator, and the minus sign.
+
+If nothing parses, the paste is **silently discarded** rather than inserting
+garbage.
+
+## Copy & cut
+
+`copyBehavior` controls what lands on the clipboard:
+
+| Value | Copy / Cut produces |
+|-------|---------------------|
+| `"formatted"` *(default)* | Browser default — the selected, formatted text |
+| `"raw"` | `String(numberValue)` — a plain ASCII number, e.g. `1234.56` |
+| `"number"` | Alias of `"raw"` |
+
+`"raw"`/`"number"` are handy when the value is consumed by another program that
+expects an unformatted number.
+
+## Mouse wheel
+
+Opt in with `allowMouseWheel`. The wheel only nudges the value **while the input
+is focused**, and the handler is attached as a **non-passive** native listener
+so it can `preventDefault()` and stop the page from scrolling.
+
+```tsx
+<NumberField.Root allowMouseWheel defaultValue={0} step={1} />
+```
+
+## Clamping & ranges
+
+`minValue` / `maxValue` define the range; `clampBehavior` decides *when* the
+value is forced into it:
+
+| `clampBehavior` | Behavior |
+|-----------------|----------|
+| `"blur"` *(default)* | Type freely; clamp to range on blur / commit. |
+| `"strict"` | Reject keystrokes that would push the value out of range. |
+| `"none"` | Never clamp automatically (steppers still respect the range). |
+
+Set **`allowOutOfRange`** to keep an out-of-range value as typed *and committed*
+— useful when the server is the source of truth. The field then exposes
+`aria-invalid` / `data-invalid` instead of snapping the value back.
+
+```tsx
+// Server validates; UI shows the value as invalid but doesn't rewrite it.
+<NumberField.Root minValue={1} maxValue={5} allowOutOfRange>
+  <NumberField.Input />
+</NumberField.Root>
+```
+
+## Fixed decimal scale
+
+`fixedDecimalScale` forces trailing zeros (`1` → `1.00`) — but it only takes
+effect when a `maximumFractionDigits` is in play, either explicitly or via the
+format. Pair it with `maximumFractionDigits` (or a format like
+`presets.financial` that already sets it):
+
+```tsx
+<NumberField.Root
+  formatOptions={{ style: "currency", currency: "USD" }}
+  fixedDecimalScale
+  maximumFractionDigits={2}
+/>
+// Always shows two decimals: $0.00, $1.50, $1,234.00
+```
+
+## Turning live formatting off
+
+`liveFormat={false}` passes normalized digits straight through with no
+reformatting until blur. This is mainly useful for IME/CJK workflows where
+partial composition should not be reformatted. During an active IME composition
+raqam already suspends formatting automatically and runs a full format cycle on
+`compositionend`.
+
+## Change reasons
+
+Every value change carries a `reason`, surfaced through
+[`onValueChange`](/api/components#numberfieldroot):
+
+| Reason | Fires when |
+|--------|------------|
+| `"input"` | The user types or edits. |
+| `"clear"` | An edit empties the field. |
+| `"paste"` | Content is pasted. |
+| `"keyboard"` | Arrow keys, Page Up/Down, Home/End change the value. |
+| `"increment"` / `"decrement"` | A stepper button (incl. press-and-hold). |
+| `"wheel"` | Mouse-wheel nudge. |
+| `"scrub"` | A [ScrubArea](/api/components#numberfieldscrubarea) drag. |
+| `"blur"` | The value settles on blur / Enter. |
+
+For "only when the value settles" semantics, prefer
+[`onValueCommitted`](/api/components#numberfieldroot), which fires once on blur
+(`reason: "blur"`) or Enter (`reason: "keyboard"`) with the final value.

--- a/skills/raqam/SKILL.md
+++ b/skills/raqam/SKILL.md
@@ -69,8 +69,9 @@ Use the simplest path that fits the user’s request:
 3. **Need display-only formatting in React:** `useNumberFieldFormat`.
 4. **Need formatting/parsing in RSC, SSR, Edge, or non-React code:** `raqam/server` / `raqam/core`.
 5. **Need non-Latin digit input:** import only the needed locale plugin (`raqam/locales/fa`, etc.).
-6. **Need analytics/change metadata:** use `onValueChange`, not raw `onChange`.
-7. **Need arbitrary-precision finance flows:** use `onRawChange` / `state.rawValue`, or custom `parseValue` / `formatValue`.
+6. **Need analytics/change metadata:** use `onValueChange` (every change + `reason`), not raw `onChange`.
+7. **Need the settled value only (persist/save/request):** use `onValueCommitted` (fires on blur/Enter).
+8. **Need arbitrary-precision finance flows:** use `onRawChange` / `state.rawValue`, or custom `parseValue` / `formatValue`.
 
 Avoid steering users toward undocumented or stale APIs when a documented path already exists.
 
@@ -78,12 +79,18 @@ Avoid steering users toward undocumented or stale APIs when a documented path al
 
 - **`locale`:** BCP 47 tag; drives `Intl.NumberFormat` / parsing.
 - **`formatOptions`:** standard `Intl.NumberFormatOptions`; use **`presets`** for common cases — [Format presets](https://47vigen.github.io/raqam/api/presets/).
-- **Controlled vs uncontrolled:** `value`/`onChange` vs `defaultValue`. `onChange` fires whenever the parsed numeric value changes; use `onValueChange` when you need `{ reason, formattedValue }` metadata — see [Getting Started](https://47vigen.github.io/raqam/getting-started/).
-- **Constraints:** `minValue`, `maxValue`, `step`, `largeStep`, `smallStep`, `clampBehavior`, `allowOutOfRange`, `allowNegative`, `allowDecimal`, `fixedDecimalScale`.
+- **Controlled vs uncontrolled:** `value`/`onChange` vs `defaultValue`. `onChange` fires whenever the parsed numeric value changes; use `onValueChange` when you need `{ reason, formattedValue }` metadata, or **`onValueCommitted`** when you only want the settled value (fires on blur → `reason:"blur"`, or Enter → `reason:"keyboard"`). See [Getting Started](https://47vigen.github.io/raqam/getting-started/).
+- **Change reasons** (`onValueChange` details.reason): `"input"`, `"clear"` (edit empties the field), `"paste"`, `"keyboard"`, `"increment"`, `"decrement"`, `"wheel"`, `"scrub"`, `"blur"`.
+- **Constraints:** `minValue`, `maxValue`, `step`, `largeStep` (default `step×10`), `smallStep` (default `step×0.1`), `clampBehavior` (`"blur"` clamp on blur / `"strict"` reject out-of-range keystrokes / `"none"`), `allowOutOfRange` (keep + commit out-of-range, set `aria-invalid`), `allowNegative`, `allowDecimal`, `fixedDecimalScale` (needs `maximumFractionDigits`).
+- **Live formatting:** formats on every keystroke with a cursor-safe algorithm; **intermediate** values (`1.`, `12.50`, `-`, `.5`) are kept as typed and only normalized on blur. **`compact`/`scientific`/`engineering` notation format on blur** (not live). Percent fields store the *fraction* (`42%` ⇒ `0.42`). Full details: [Formatting & Behavior](https://47vigen.github.io/raqam/guides/formatting/).
+- **Paste:** strips currency symbols, parses scientific/compact (`1e3`, `1.5K`) and accounting parens `(1,234)` ⇒ negative; unparseable pastes are discarded.
+- **Clipboard:** `copyBehavior` `"formatted"` (default) / `"raw"` / `"number"`.
+- **Wheel:** opt-in `allowMouseWheel`; only nudges while the input is focused.
 - **Validation:** `validate` returning `true` / error string; pairs with `NumberField.ErrorMessage`.
 - **Precision / finance:** `onRawChange` and `state.rawValue` for exact string before float conversion; optional custom `formatValue` / `parseValue`.
 - **Display-only:** [useNumberFieldFormat](https://47vigen.github.io/raqam/api/use-number-field-format/) on the client; **`createFormatter` from `raqam/server`** on the server.
 - **Forms:** for native form submission, put `name` on `NumberField.Root` and render `NumberField.HiddenInput`.
+- **Hook API gotcha:** when using `useNumberFieldState` + `useNumberField` directly, pass the **same formatting options to both** (the behavior hook builds its own formatter/parser). The `NumberField.*` components do this for you.
 
 ## Locales and RTL
 
@@ -134,6 +141,7 @@ Avoid steering users toward undocumented or stale APIs when a documented path al
 | useNumberFieldState | [https://47vigen.github.io/raqam/api/use-number-field-state/](https://47vigen.github.io/raqam/api/use-number-field-state/) |
 | useNumberField | [https://47vigen.github.io/raqam/api/use-number-field/](https://47vigen.github.io/raqam/api/use-number-field/) |
 | NumberField components | [https://47vigen.github.io/raqam/api/components/](https://47vigen.github.io/raqam/api/components/) |
+| Formatting & Behavior | [https://47vigen.github.io/raqam/guides/formatting/](https://47vigen.github.io/raqam/guides/formatting/) |
 | useNumberFieldFormat | [https://47vigen.github.io/raqam/api/use-number-field-format/](https://47vigen.github.io/raqam/api/use-number-field-format/) |
 | Format presets | [https://47vigen.github.io/raqam/api/presets/](https://47vigen.github.io/raqam/api/presets/) |
 | Core utilities | [https://47vigen.github.io/raqam/api/core-utilities/](https://47vigen.github.io/raqam/api/core-utilities/) |

--- a/skills/raqam/examples.md
+++ b/skills/raqam/examples.md
@@ -75,19 +75,20 @@ import { NumberField } from "raqam";
 
 ```tsx
 import { useRef } from "react";
-import { useNumberFieldState, useNumberField } from "raqam";
+import { useNumberFieldState, useNumberField, type UseNumberFieldStateOptions } from "raqam";
 
 function PriceInput() {
   const inputRef = useRef<HTMLInputElement>(null);
 
   // Share one options object — useNumberField builds its own formatter/parser
-  // and needs the SAME formatting options as the state hook.
+  // and needs the SAME formatting options as the state hook. `satisfies` keeps
+  // the literal types (e.g. style: "currency") in a strict TS project.
   const options = {
     locale: "en-US",
     formatOptions: { style: "currency", currency: "USD" },
     minValue: 0,
     defaultValue: 1234.56,
-  };
+  } satisfies UseNumberFieldStateOptions;
 
   const state = useNumberFieldState(options);
   const { inputProps, labelProps, incrementButtonProps, decrementButtonProps } =

--- a/skills/raqam/examples.md
+++ b/skills/raqam/examples.md
@@ -79,14 +79,19 @@ import { useNumberFieldState, useNumberField } from "raqam";
 
 function PriceInput() {
   const inputRef = useRef<HTMLInputElement>(null);
-  const state = useNumberFieldState({
+
+  // Share one options object — useNumberField builds its own formatter/parser
+  // and needs the SAME formatting options as the state hook.
+  const options = {
     locale: "en-US",
     formatOptions: { style: "currency", currency: "USD" },
     minValue: 0,
     defaultValue: 1234.56,
-  });
+  };
+
+  const state = useNumberFieldState(options);
   const { inputProps, labelProps, incrementButtonProps, decrementButtonProps } =
-    useNumberField({ label: "Price" }, state, inputRef);
+    useNumberField({ ...options, label: "Price" }, state, inputRef);
 
   return (
     <div>
@@ -141,6 +146,57 @@ const displayPrice = formatter.format(1234.56);
 
 Use `onValueChange` when the calling app needs to know whether the change came
 from typing, paste, wheel, increment/decrement, blur, or scrubbing.
+
+## Commit-only callback (save the settled value)
+
+```tsx
+<NumberField.Root
+  locale="en-US"
+  formatOptions={{ style: "currency", currency: "USD" }}
+  defaultValue={0}
+  minValue={0}
+  onValueCommitted={(value, { reason }) => {
+    // Fires once the value settles: reason "blur" (focus loss) or "keyboard" (Enter).
+    void fetch("/api/price", { method: "POST", body: JSON.stringify({ value }) });
+  }}
+>
+  <NumberField.Label>Price</NumberField.Label>
+  <NumberField.Input />
+</NumberField.Root>
+```
+
+`onValueCommitted` fires after formatting + clamping with the final value — use it
+instead of `onChange`/`onValueChange` when you only care about the settled value.
+
+## ScrubArea (drag to change)
+
+```tsx
+<NumberField.Root locale="en-US" defaultValue={50} minValue={0} maxValue={100}>
+  <NumberField.ScrubArea direction="horizontal" pixelSensitivity={2}>
+    <NumberField.Label>Opacity</NumberField.Label>
+    <NumberField.ScrubAreaCursor>⟺</NumberField.ScrubAreaCursor>
+  </NumberField.ScrubArea>
+  <NumberField.Input />
+</NumberField.Root>
+```
+
+The scrub area uses the Pointer Lock API and is keyboard accessible
+(`role="slider"`, arrow keys step the value).
+
+## Strict clamp + out-of-range
+
+```tsx
+// "strict": reject keystrokes that would push the value out of range.
+<NumberField.Root locale="en-US" minValue={0} maxValue={10} clampBehavior="strict">
+  <NumberField.Input />
+</NumberField.Root>
+
+// allowOutOfRange: keep + commit the typed value, flag it invalid (server validates).
+<NumberField.Root locale="en-US" minValue={1} maxValue={5} allowOutOfRange>
+  <NumberField.Input />
+  <NumberField.ErrorMessage>Out of range</NumberField.ErrorMessage>
+</NumberField.Root>
+```
 
 ## react-hook-form (Controller)
 

--- a/skills/raqam/reference.md
+++ b/skills/raqam/reference.md
@@ -1,83 +1,162 @@
 # raqam — reference digest
 
-Use this file for **quick lookup**. Authoritative detail lives in the official docs and README (see [SKILL.md](SKILL.md) canonical links).
+Self-contained quick lookup. For prose/examples and live demos see the official
+docs and [SKILL.md](SKILL.md) canonical links. Confirm the current version on npm.
 
-## Official references (external)
+## Entry points
 
-- **README API tables:** [https://github.com/47vigen/raqam/blob/main/README.md](https://github.com/47vigen/raqam/blob/main/README.md)
-- **useNumberFieldState options & state shape:** [https://47vigen.github.io/raqam/api/use-number-field-state/](https://47vigen.github.io/raqam/api/use-number-field-state/)
-- **useNumberField props & NumberFieldAria keys:** [https://47vigen.github.io/raqam/api/use-number-field/](https://47vigen.github.io/raqam/api/use-number-field/)
-- **NumberField.* components:** [https://47vigen.github.io/raqam/api/components/](https://47vigen.github.io/raqam/api/components/)
-- **presets:** [https://47vigen.github.io/raqam/api/presets/](https://47vigen.github.io/raqam/api/presets/)
+| Import | Provides |
+|--------|----------|
+| `raqam` | `NumberField`, `useNumberFieldState`, `useNumberField`, `useNumberFieldFormat`, `useControllableState`, `usePressAndHold`, `useScrubArea`, `NumberFieldContext`, `useNumberFieldContext`, plus all core re-exports + types |
+| `raqam/react` | Same hooks/components (alternate React entry) |
+| `raqam/core` | No React: `createFormatter`, `createParser`, `normalizeDigits`, `registerLocale`, `getCaretBoundary`, `computeNewCursorPosition`, `presets` + types |
+| `raqam/server` | **Alias of `raqam/core`** — safe in RSC / Edge / Node (zero React deps) |
+| `raqam/locales/<lang>` | Side-effect digit plugins: `fa`, `ar`, `bn`, `hi`, `th` |
+| `raqam/locales` | Registers all plugins; re-exports `FA_LOCALE_CODES` … `TH_LOCALE_CODES` |
 
-## useNumberFieldState — option groups (summary)
+Peer deps: **React 18 or 19** (+ `react-dom`).
 
-| Area | Examples |
-|------|-----------|
-| Value | `value`, `defaultValue`, `onChange`, `onRawChange` |
-| Locale / format | `locale`, `formatOptions`, `prefix`, `suffix`, `fixedDecimalScale`, `liveFormat` |
-| Bounds / step | `minValue`, `maxValue`, `step`, `largeStep`, `smallStep`, `clampBehavior`, `allowOutOfRange` |
-| Input rules | `allowNegative`, `allowDecimal`, `maximumFractionDigits`, `minimumFractionDigits` |
-| Validation | `validate` |
-| Custom | `formatValue`, `parseValue` |
-| UX timing | `stepHoldDelay`, `stepHoldInterval`, `disabled`, `readOnly` |
+## `useNumberFieldState(options)` → `NumberFieldState`
 
-## NumberField.Root — extras (summary)
+| Option | Type | Default | Notes |
+|--------|------|---------|-------|
+| `value` | `number \| null` | — | Controlled value |
+| `defaultValue` | `number \| null` | `null` | Uncontrolled initial value |
+| `onChange` | `(v: number \| null) => void` | — | Fires when the parsed value changes |
+| `onRawChange` | `(raw: string \| null) => void` | — | Exact typed string, pre-float |
+| `locale` | `string` | runtime | BCP 47 tag |
+| `formatOptions` | `Intl.NumberFormatOptions` | `{}` | Full Intl options |
+| `minValue` / `maxValue` | `number` | — | Range |
+| `step` | `number` | `1` | ↑/↓ |
+| `largeStep` | `number` | `step×10` | Shift+↑/↓, PageUp/Down |
+| `smallStep` | `number` | `step×0.1` | Ctrl/Cmd+↑/↓ |
+| `clampBehavior` | `"blur" \| "strict" \| "none"` | `"blur"` | When to clamp |
+| `allowOutOfRange` | `boolean` | `false` | Keep+commit out-of-range, set `aria-invalid` |
+| `allowNegative` | `boolean` | `true` | |
+| `allowDecimal` | `boolean` | `true` | |
+| `maximumFractionDigits` | `number` | — | Override format |
+| `minimumFractionDigits` | `number` | — | Override format |
+| `fixedDecimalScale` | `boolean` | `false` | Needs `maximumFractionDigits` to apply |
+| `prefix` / `suffix` | `string` | — | e.g. `"$"`, `" تومان"` |
+| `liveFormat` | `boolean` | `true` | Off ⇒ format on blur only |
+| `validate` | `(v) => boolean \| string \| null \| undefined` | — | `string` ⇒ error message |
+| `disabled` / `readOnly` / `required` | `boolean` | `false` | |
+| `formatValue` | `(v: number) => string` | — | Custom formatter |
+| `parseValue` | `(s: string) => { value: number\|null; isIntermediate: boolean }` | — | Custom parser |
 
-Beyond state options, the component API adds **`onValueChange`** for
-`{ reason, formattedValue }` metadata. See
-[components doc](https://47vigen.github.io/raqam/api/components/).
+### `NumberFieldState`
 
-For native forms, pair `name` on `NumberField.Root` with
-`NumberField.HiddenInput`.
+`inputValue: string` · `numberValue: number \| null` · `rawValue: string \| null`
+· `isFocused` / `isScrubbing: boolean` · `canIncrement` / `canDecrement: boolean`
+· `validationState: "valid"\|"invalid"` · `validationError: string \| null`
+· `increment(amount?)` · `decrement(amount?)` · `incrementToMax()` · `decrementToMin()`
+· `setInputValue(s, knownValue?)` · `setNumberValue(n)` · **`commit(): number \| null`**
+· `setIsFocused(b)` · `setIsScrubbing(b)` · `options`.
 
-## useNumberField — notable props
+## `useNumberField(props, state, inputRef)` → `NumberFieldAria`
 
-- **`copyBehavior`:** `"formatted"` | `"raw"` | `"number"` — clipboard semantics ([doc](https://47vigen.github.io/raqam/api/use-number-field/)).
-- **`allowMouseWheel`:** opt-in wheel nudging (see docs).
+Accepts every `useNumberFieldState` option **plus**:
 
-## Locale plugins (built-in)
+| Prop | Type | Default | Notes |
+|------|------|---------|-------|
+| `label` | `string` | — | aria-label fallback |
+| `id` | `string` | auto | input id (else `useId`) |
+| `aria-label` / `aria-labelledby` / `aria-describedby` | `string` | — | Naming/description wiring |
+| `name` | `string` | — | enables `hiddenInputProps` |
+| `allowMouseWheel` | `boolean` | `false` | wheel nudges while focused (non-passive) |
+| `copyBehavior` | `"formatted" \| "raw" \| "number"` | `"formatted"` | clipboard on copy/cut |
+| `stepHoldDelay` | `number` | `400` | press-and-hold delay (ms) |
+| `stepHoldInterval` | `number` | `200` | press-and-hold repeat (ms), accelerates to 50ms |
+| `onFocus` / `onBlur` | `(e) => void` | — | |
+| `onValueCommitted` | `(v, { reason: "blur"\|"keyboard" }) => void` | — | fires on blur/Enter, post-clamp |
 
-| Import | Scripts / notes |
-|--------|------------------|
-| `raqam/locales/fa` | Persian digits |
-| `raqam/locales/ar` | Arabic-Indic digits |
-| `raqam/locales/bn` | Bengali digits |
-| `raqam/locales/hi` | Devanagari digits |
-| `raqam/locales/th` | Thai digits |
+**Gotcha:** pass the same formatting options to both hooks (the behavior hook
+builds its own formatter/parser).
 
-Full table and `registerLocale` custom digits: [Locales & i18n](https://47vigen.github.io/raqam/guides/locales/).
+### `NumberFieldAria` keys → element
 
-## Server / core
+`labelProps` (→ `<label>`, includes a registration `ref` — keep it) · `groupProps`
+(→ `<div role="group">`) · `inputProps` (→ `<input role="spinbutton">`) ·
+`incrementButtonProps` / `decrementButtonProps` (→ `<button>`, `aria-label`
+`"Increase"`/`"Decrease"`, `tabIndex={-1}`) · `hiddenInputProps` (→ hidden input or
+`null`) · `descriptionProps` · `errorMessageProps` (`role="alert"`).
 
-`raqam/server` and `raqam/core` expose **`createFormatter`**,
-**`createParser`**, **`normalizeDigits`**, **`registerLocale`**,
-**`getCaretBoundary`**, **`computeNewCursorPosition`**, and **`presets`**.
-Details: [Core utilities](https://47vigen.github.io/raqam/api/core-utilities/)
-and [Next.js guide](https://47vigen.github.io/raqam/guides/nextjs/).
+## `NumberField.*` components
+
+`Root` · `Label` · `Group` · `Input` · `Increment` · `Decrement` · `HiddenInput`
+· `ScrubArea` (Pointer Lock; `role="slider"`, arrow-key accessible; props
+`direction` `"horizontal"|"vertical"|"both"`, `pixelSensitivity` default 4) ·
+`ScrubAreaCursor` (renders only while scrubbing) · `Description` (not auto-linked —
+set `aria-describedby` on `Input` yourself) · `ErrorMessage` (auto-renders
+`validationError`) · `Formatted` (`aria-hidden` read-only display).
+
+`Label`/`Group`/`Input`/`Increment`/`Decrement`/`ScrubArea`/`ScrubAreaCursor`/
+`Formatted` accept a **`render`** prop (element or `(props, state) => element`).
+
+### `NumberField.Root` extras (beyond state/behavior options)
+
+- `onValueChange(value, { reason, formattedValue, event? })` — every change.
+- `onValueCommitted(value, { reason: "blur" \| "keyboard" })` — settled value only.
+- `className` / `style` — applied to the root wrapper `<div>`.
+
+## Change reasons (`ChangeReason`)
+
+`"input"` · `"clear"` (edit empties field) · `"blur"` · `"paste"` · `"keyboard"`
+(arrows / PageUp-Down / Home-End) · `"increment"` · `"decrement"` · `"wheel"` · `"scrub"`.
+
+## Keyboard
+
+↑/↓ step · Shift+↑/↓ largeStep · Ctrl/Cmd+↑/↓ smallStep · PageUp/Down largeStep ·
+Home/End → min/max (only when set) · Enter commit (fires `onValueCommitted`) ·
+Backspace deletes through grouping separators and trailing affordances; typing the
+decimal separator when one exists jumps the caret after it.
+
+## `presets` (formatOptions builders)
+
+`currency(code)` · `accounting(code)` (negatives in parens) · `percent` (stores
+fraction) · `compact` · `compactLong` · `scientific` · `engineering` · `integer`
+· `financial` (min/max fraction 2) · `unit(unitCode)`. `compact`/`scientific`/
+`engineering` format **on blur**, not live.
+
+## Locale plugins
+
+| Import | Digits |
+|--------|--------|
+| `raqam/locales/fa` | Persian ۰–۹ (+ Arabic-Indic) |
+| `raqam/locales/ar` | Arabic-Indic ٠–٩ |
+| `raqam/locales/bn` | Bengali ০–৯ |
+| `raqam/locales/hi` | Devanagari ०–९ (covers mr, ne) |
+| `raqam/locales/th` | Thai ๐–๙ |
+
+Custom digits: `registerLocale({ digitBlocks: [[start, end]] })`.
+
+## Core / server API
+
+`createFormatter(opts)` → `{ format, formatToParts, formatResult, getLocaleInfo }`
+· `createParser(opts)` → `{ parse, isIntermediate, getLocaleInfo }`
+· `normalizeDigits(s)` · `registerLocale(cfg)` · `getCaretBoundary(formatted, info)`
+· `computeNewCursorPosition(old, oldCaret, newFormatted, info, inputType?)` · `presets`.
+
+Result types: `LocaleInfo { decimalSeparator, groupingSeparator, minusSign, zero, isRTL }`
+· `ParseResult { value, isValid, isIntermediate }` · `FormatResult { formatted, parts }`.
 
 ## Advanced primitives
 
-When a developer is building a wrapper library or custom primitive layer, use
-the dedicated lower-level APIs:
+`useControllableState` · `usePressAndHold(cb, { delay, interval, disabled })` ·
+`useScrubArea(state, { direction, pixelSensitivity })` → `{ isScrubbing, scrubAreaProps, virtualCursor }`
+· `NumberFieldContext` / `useNumberFieldContext()` → `{ state, aria, inputRef, props }`.
 
-- `useControllableState`
-- `usePressAndHold`
-- `useScrubArea`
-- `NumberFieldContext`
-- `useNumberFieldContext`
+## Data attributes (CSS)
 
-Reference: [Advanced primitives](https://47vigen.github.io/raqam/api/advanced-primitives/).
+- **Root:** `data-focused`, `data-invalid`, `data-disabled`, `data-readonly`, `data-required`, `data-scrubbing`.
+- **Input:** `data-rtl`, plus `data-invalid` / `data-disabled` / `data-readonly` / `data-required`.
 
-## Styling hooks
+## Exported types
 
-- Root: `data-focused`, `data-invalid`, `data-disabled`, `data-readonly`,
-  `data-required`, `data-scrubbing`
-- Input: `data-rtl`
-
-Use the root state hooks for general styling and `input[data-rtl]` only for
-RTL-specific input adjustments.
-
-## Types (TypeScript)
-
-Export names like `UseNumberFieldStateOptions`, `NumberFieldState`, `UseNumberFieldProps`, `NumberFieldAria`, `ChangeReason` — see [Getting Started](https://47vigen.github.io/raqam/getting-started/) TypeScript section and published `.d.ts` on npm.
+`UseNumberFieldStateOptions`, `NumberFieldState`, `UseNumberFieldProps`,
+`NumberFieldAria`, `NumberFieldRootProps`, `ChangeReason`, `LocaleInfo`,
+`FormatResult`, `ParseResult`, `CaretBoundary`, `DigitBlock`, `ScrubAreaOptions`,
+`ScrubAreaProps`, `ScrubAreaCursorProps`, `RenderProp`, `StateRenderFn`,
+`NumberFieldContextValue`, `FormatterOptions`, `Formatter`, `ParserOptions`,
+`Parser`, `LocaleConfig`, `UsePressAndHoldOptions`, `PressAndHoldProps`,
+`ScrubAreaReturn`.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -166,8 +166,8 @@ export interface NumberFieldState {
   setInputValue: (val: string, knownValue?: number | null) => void;
   /** Directly set the numeric value (triggers format + onChange) */
   setNumberValue: (val: number | null) => void;
-  /** Format + clamp on blur — call from onBlur */
-  commit: () => void;
+  /** Format + clamp on blur — call from onBlur. Returns the committed numeric value. */
+  commit: () => number | null;
   /** Increment by step */
   increment: (amount?: number) => void;
   /** Decrement by step */
@@ -219,6 +219,14 @@ export interface UseNumberFieldProps extends UseNumberFieldStateOptions {
   stepHoldInterval?: number;
   onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
+  /**
+   * Fires only when the value is committed — i.e. on blur, or when the user
+   * presses Enter — after formatting and clamping have been applied.
+   * `reason` is `"blur"` for focus loss and `"keyboard"` for Enter.
+   * Reach for this (instead of `onChange`) when you only care about the final,
+   * settled value: persisting it, validating server-side, firing a request, etc.
+   */
+  onValueCommitted?: (value: number | null, details: { reason: "blur" | "keyboard" }) => void;
   // Note: formatValue and parseValue are inherited from UseNumberFieldStateOptions
 }
 
@@ -284,6 +292,5 @@ export interface NumberFieldRootProps extends UseNumberFieldProps {
       event?: React.SyntheticEvent;
     }
   ) => void;
-  /** Fires only on commit (blur, Enter) */
-  onValueCommitted?: (value: number | null, details: { reason: "blur" | "keyboard" }) => void;
+  // `onValueCommitted` is inherited from `UseNumberFieldProps`.
 }

--- a/src/react/NumberField.test.tsx
+++ b/src/react/NumberField.test.tsx
@@ -291,6 +291,33 @@ describe("NumberField clear reason", () => {
     expect(value).toBeNull();
     expect(details.reason).toBe("clear");
   });
+
+  it("reports reason 'clear' when backspacing the last digit before an affordance", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(
+      <NumberField.Root
+        locale="en-US"
+        formatOptions={{ style: "percent" }}
+        defaultValue={0.05}
+        onValueChange={onValueChange}
+      >
+        <NumberField.Input data-testid="input" />
+      </NumberField.Root>
+    );
+    const input = screen.getByTestId("input") as HTMLInputElement;
+    // Displays "5%"; Backspace from the end is handled by the smart-affordance
+    // keydown branch (not the onChange path) and empties the field.
+    await user.click(input);
+    input.setSelectionRange(input.value.length, input.value.length);
+    await user.keyboard("{Backspace}");
+
+    expect(onValueChange).toHaveBeenCalled();
+    const calls = onValueChange.mock.calls;
+    const [value, details] = calls[calls.length - 1] as [number | null, { reason: string }];
+    expect(value).toBeNull();
+    expect(details.reason).toBe("clear");
+  });
 });
 
 describe("NumberField render prop", () => {

--- a/src/react/NumberField.test.tsx
+++ b/src/react/NumberField.test.tsx
@@ -225,6 +225,74 @@ describe("NumberField blur behavior", () => {
   });
 });
 
+describe("NumberField onValueCommitted", () => {
+  it("fires on blur with reason 'blur' and the clamped value", async () => {
+    const user = userEvent.setup();
+    const onValueCommitted = vi.fn();
+    render(
+      <NumberField.Root
+        locale="en-US"
+        defaultValue={5}
+        maxValue={10}
+        onValueCommitted={onValueCommitted}
+      >
+        <NumberField.Input data-testid="input" />
+      </NumberField.Root>
+    );
+    const input = screen.getByTestId("input");
+    await user.click(input);
+    await user.keyboard("99"); // 599 — clamps to maxValue on blur
+    await user.tab();
+
+    expect(onValueCommitted).toHaveBeenCalled();
+    const committedCalls = onValueCommitted.mock.calls;
+    const [value, details] = committedCalls[committedCalls.length - 1] as [
+      number | null,
+      { reason: string },
+    ];
+    expect(details.reason).toBe("blur");
+    expect(value).toBe(10);
+  });
+
+  it("fires on Enter with reason 'keyboard'", async () => {
+    const user = userEvent.setup();
+    const onValueCommitted = vi.fn();
+    render(
+      <NumberField.Root locale="en-US" defaultValue={3} onValueCommitted={onValueCommitted}>
+        <NumberField.Input data-testid="input" />
+      </NumberField.Root>
+    );
+    const input = screen.getByTestId("input");
+    await user.click(input);
+    await user.keyboard("{Enter}");
+
+    expect(onValueCommitted).toHaveBeenCalledWith(3, { reason: "keyboard" });
+  });
+});
+
+describe("NumberField clear reason", () => {
+  it("reports reason 'clear' when the field is emptied", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(
+      <NumberField.Root locale="en-US" defaultValue={42} onValueChange={onValueChange}>
+        <NumberField.Input data-testid="input" />
+      </NumberField.Root>
+    );
+    const input = screen.getByTestId("input");
+    await user.clear(input);
+
+    expect(onValueChange).toHaveBeenCalled();
+    const changeCalls = onValueChange.mock.calls;
+    const [value, details] = changeCalls[changeCalls.length - 1] as [
+      number | null,
+      { reason: string },
+    ];
+    expect(value).toBeNull();
+    expect(details.reason).toBe("clear");
+  });
+});
+
 describe("NumberField render prop", () => {
   it("renders custom element via render prop (element form)", () => {
     render(

--- a/src/react/NumberField.tsx
+++ b/src/react/NumberField.tsx
@@ -113,6 +113,8 @@ const Root = forwardRef<HTMLDivElement, NumberFieldRootProps>(function NumberFie
   // returns the correct reason at the time onChange fires.
   const wrappedProps = {
     ...props,
+    // Forward onValueCommitted to the behavior hook, which fires it on blur/Enter.
+    onValueCommitted,
     onChange: (value: number | null) => {
       props.onChange?.(value);
       if (onValueChangeRef.current && stateRef.current) {

--- a/src/react/useNumberField.ts
+++ b/src/react/useNumberField.ts
@@ -76,6 +76,7 @@ export function useNumberField(
     stepHoldInterval = 200,
     formatValue: customFormatValue,
     parseValue: customParseValue,
+    onValueCommitted,
   } = props; // formatValue/parseValue are on UseNumberFieldStateOptions (inherited)
 
   // Compact/scientific/engineering notation produce formatted strings ("2.5K",
@@ -409,7 +410,9 @@ export function useNumberField(
         pendingCursor.current = cursorPos;
       }
 
-      state._setLastChangeReason("input");
+      // An edit that empties the field reports the dedicated "clear" reason so
+      // consumers can distinguish a deletion-to-empty from ordinary typing.
+      state._setLastChangeReason(displayValue === "" ? "clear" : "input");
       state.setInputValue(displayValue, knownValue);
     },
     [
@@ -719,7 +722,8 @@ export function useNumberField(
 
       if (key === "Enter") {
         state._setLastChangeReason("blur");
-        state.commit();
+        const committed = state.commit();
+        onValueCommitted?.(committed, { reason: "keyboard" });
         return;
       }
     },
@@ -737,6 +741,7 @@ export function useNumberField(
       inputRef,
       allowDecimal,
       formatGroupedFraction,
+      onValueCommitted,
     ]
   );
 
@@ -745,10 +750,11 @@ export function useNumberField(
     (e: React.FocusEvent<HTMLInputElement>) => {
       state.setIsFocused(false);
       state._setLastChangeReason("blur");
-      state.commit();
+      const committed = state.commit();
+      onValueCommitted?.(committed, { reason: "blur" });
       onBlur?.(e);
     },
-    [state, onBlur]
+    [state, onBlur, onValueCommitted]
   );
 
   // ── Focus handler ────────────────────────────────────────────────────────

--- a/src/react/useNumberField.ts
+++ b/src/react/useNumberField.ts
@@ -527,7 +527,8 @@ export function useNumberField(
       e.preventDefault();
       const text = String(state.numberValue ?? "");
       e.clipboardData.setData("text/plain", text);
-      // Clear the field after cut
+      // Clear the field after cut — report the dedicated "clear" reason.
+      state._setLastChangeReason("clear");
       state.setInputValue("");
     },
     [copyBehavior, state]
@@ -605,8 +606,10 @@ export function useNumberField(
                 liveFormatter.format(parseResult.value);
               state.setInputValue(nextDisplay, parseResult.value);
             } else {
-              // Empty or intermediate — store as-is (blur will clean up)
+              // Empty or intermediate — store as-is (blur will clean up). If the
+              // edit emptied the field, report the dedicated "clear" reason.
               nextDisplay = rawEdited;
+              if (rawEdited === "") state._setLastChangeReason("clear");
               state.setInputValue(rawEdited);
             }
             // Remap the caret through the cursor engine so re-grouping shifts
@@ -658,7 +661,9 @@ export function useNumberField(
                 state.setInputValue(nextDisplay, parseResult.value);
               } else {
                 // No digits left — clear the field (don't strand the affordance).
+                // Report the dedicated "clear" reason like the onChange path.
                 nextDisplay = "";
+                state._setLastChangeReason("clear");
                 state.setInputValue("");
               }
               pendingCursor.current = computeNewCursorPosition(

--- a/src/react/useNumberFieldState.ts
+++ b/src/react/useNumberFieldState.ts
@@ -304,11 +304,11 @@ export function useNumberFieldState(options: UseNumberFieldStateOptions): Number
   );
 
   // ── commit (called on blur) ────────────────────────────────────────────────
-  const commit = useCallback(() => {
+  const commit = useCallback((): number | null => {
     if (numberValue == null) {
       setInputValueRaw("");
       lastFormattedRef.current = "";
-      return;
+      return null;
     }
 
     let clamped = numberValue;
@@ -342,6 +342,7 @@ export function useNumberFieldState(options: UseNumberFieldStateOptions): Number
       setNumberValue(committed);
     }
     applyValidation(committed);
+    return committed;
   }, [
     numberValue,
     clampBehavior,


### PR DESCRIPTION
## Summary

Comprehensive update to the documentation site and the `raqam` agent skill, plus a small source fix that makes a documented-but-dead public API actually work.

**Docs site**
- New **Formatting & Input Behavior** guide ([`guides/formatting`](docs/src/content/docs/guides/formatting.mdx)): the live cursor algorithm, intermediate states, notation-formats-on-blur, percent storage, decimal-separator handling, smart backspace/decimal, paste, copy/cut, mouse wheel, `clampBehavior`/`allowOutOfRange`, `fixedDecimalScale`, and the full change-reason table. Wired into the sidebar.
- Expanded the API pages (components, useNumberField, useNumberFieldState, presets, core-utilities) and getting-started: documented `onValueCommitted`, the `"clear"` reason, the shared-options requirement for the Hook API, `commit()`'s return value, and the `fixedDecimalScale` requirement.

**Agent skill (`skills/raqam`)**
- Rewrote `reference.md` into a detailed, self-contained digest; expanded `SKILL.md` behavior notes and `examples.md`; fixed the hook example to share one options object between `useNumberFieldState` and `useNumberField`.

**Source fix (`feat`, first commit)**
- `onValueCommitted` was part of the public type and documented, but `NumberField.Root` never called it. It now fires once the value is committed — on blur (`reason: "blur"`) and Enter (`reason: "keyboard"`) after formatting/clamping — and is now accepted on the `useNumberField` hook too.
- The `"clear"` `ChangeReason` is now emitted when an edit empties the field.
- `NumberFieldState.commit()` now returns the committed value (`number | null`).

This source change is what makes the docs *accurate* (they previously described a dead prop). It is isolated to the first commit + changeset, so it can be dropped independently if you'd prefer docs-only.

## Checklist

- [x] Tests added or updated for new behavior (blur / Enter / clear paths)
- [x] `pnpm test` passes locally (604 passed)
- [x] `pnpm typecheck` passes (0 errors)
- [x] `pnpm lint` passes (Biome) — 0 errors on changed files
- [x] Changeset added (`minor`) for the user-facing `onValueCommitted` / `"clear"` change
- [x] Docs updated for the public API change
- [ ] Stories added/updated in Storybook — N/A (no UI/visual changes)

## Related issues

N/A — no associated issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
