### PR TITLE
fix: preserve consumer ref cleanups on React 18

### DIFF
--- a/.changeset/fix-react18-ref-cleanup.md
+++ b/.changeset/fix-react18-ref-cleanup.md
@@ -1,0 +1,16 @@
+---
+"raqam": patch
+---
+
+Fix consumer ref cleanups being dropped on React 18
+
+`mergeRefs` returned a cleanup function from its callback ref. React 19 runs that
+cleanup on detach, but React ≤18 ignores it (logging "A callback ref should not
+return a function") and instead calls the ref with `null` — so a consumer ref's
+cleanup never ran on unmount, and the spurious warning showed up in tests.
+
+`mergeRefs` now branches on the React version: it keeps returning a cleanup on
+React 19, and on React ≤18 it stashes the per-ref cleanups in a closure and runs
+them when React calls the merged ref with `null`. Composed consumer refs (e.g. on
+`<NumberField.Label>` or a render-prop element) now clean up correctly on both
+React 18 and 19, with no callback-ref warning.

--- a/src/react/NumberField.tsx
+++ b/src/react/NumberField.tsx
@@ -53,7 +53,10 @@ function renderWith(
 // React 19 exposes a React element's `ref` as a regular prop; React ≤18 stores
 // it on the element itself (and reading `element.ref` on React 19 logs a
 // deprecation warning), so branch on the version to read it without warnings.
+// The same version boundary marks where callback refs may return a cleanup
+// function: React 19 runs it on detach, React ≤18 ignores it (and warns).
 const REF_IN_PROPS = Number.parseInt(React.version, 10) >= 19;
+const SUPPORTS_REF_CLEANUP = REF_IN_PROPS;
 
 function getElementRef(el: React.ReactElement): React.Ref<unknown> | undefined {
   if (REF_IN_PROPS) return (el.props as { ref?: React.Ref<unknown> }).ref;
@@ -61,14 +64,20 @@ function getElementRef(el: React.ReactElement): React.Ref<unknown> | undefined {
 }
 
 /**
- * Compose multiple refs (callback or object) into one callback ref. Honors
- * React 19 cleanup-returning callback refs: each function ref's returned cleanup
- * (or a synthesized `ref(null)` for legacy refs / `current = null` for object
- * refs) is collected and run from the combined ref's own returned cleanup, so
- * consumer cleanups aren't dropped on unmount/ref change.
+ * Compose multiple refs (callback or object) into one callback ref while
+ * preserving each ref's cleanup. For every ref we capture a cleanup — a function
+ * ref's returned cleanup, a synthesized `ref(null)` for legacy refs, or
+ * `current = null` for object refs — so consumer cleanups aren't dropped on
+ * unmount or ref change.
+ *
+ * The two React eras differ in HOW the combined cleanup gets back to React:
+ * - React 19 runs a cleanup returned from a callback ref, so we return one.
+ * - React ≤18 ignores (and warns about) a returned function and instead calls
+ *   the ref with `null` on detach, so we stash the cleanups in a closure and run
+ *   them on that `null` call rather than returning a function.
  */
 function mergeRefs<T>(...refs: (React.Ref<T> | undefined)[]): React.RefCallback<T> {
-  return (node) => {
+  const attach = (node: T | null): (() => void)[] => {
     const cleanups: (() => void)[] = [];
     for (const ref of refs) {
       if (ref == null) continue;
@@ -82,9 +91,23 @@ function mergeRefs<T>(...refs: (React.Ref<T> | undefined)[]): React.RefCallback<
         });
       }
     }
-    return () => {
-      for (const cleanup of cleanups) cleanup();
+    return cleanups;
+  };
+
+  if (SUPPORTS_REF_CLEANUP) {
+    return (node) => {
+      const cleanups = attach(node);
+      return () => {
+        for (const cleanup of cleanups) cleanup();
+      };
     };
+  }
+
+  // React ≤18: drive cleanups off the `null` detach call instead of a return.
+  let cleanups: (() => void)[] = [];
+  return (node) => {
+    for (const cleanup of cleanups) cleanup();
+    cleanups = node == null ? [] : attach(node);
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes the failing **React 18** CI matrix leg ([run 28132401240](https://github.com/47vigen/raqam/actions/runs/28132401240/job/83311515025)), where two `NumberField` tests failed with `expected "spy" to be called 1 times, but got 0 times`, alongside the warning `A callback ref should not return a function`.

**Root cause:** `mergeRefs` returned a cleanup function from its merged callback ref. React 19 runs that cleanup on detach, but React ≤18 ignores it (and warns) and instead calls the ref with `null` on unmount — so a consumer ref's cleanup was silently dropped on React 18. This is a real user-facing bug, not just a test artifact: any consumer passing a cleanup-returning ref to `<NumberField.Label>` (or a render-prop element) leaked its cleanup on React 18.

**Fix:** `mergeRefs` now branches on the React version (reusing the existing `>= 19` boundary as `SUPPORTS_REF_CLEANUP`):
- **React 19** — unchanged: return a cleanup function.
- **React ≤18** — stash the per-ref cleanups in a closure and run them when React calls the merged ref with `null`; return nothing, so the warning is gone.

## Verification

- React 19: full suite **615/615 pass**.
- React 18 (installed locally to reproduce, then restored): full suite **615/615 pass**, `NumberField` **66/66**, callback-ref warning **gone (0 occurrences)**.
- `pnpm typecheck` passes; lint clean on the changed file.

The only source change is `src/react/NumberField.tsx`; the two previously-failing tests now cover both React versions.

## Checklist

- [x] Tests added or updated for new behavior (existing tests now pass on React 18)
- [x] `pnpm test` passes locally
- [x] `pnpm typecheck` passes (0 errors)
- [x] `pnpm lint` passes (Biome) — no new findings on the changed file
- [x] Changeset added (`pnpm changeset`) for any user-facing changes
- [ ] Docs updated if the public API changed — N/A (internal helper, no API change)
- [ ] Stories added/updated in Storybook for UI changes — N/A

## Related issues

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)