### PR TITLE
fix: close ReDoS, RTL/scientific parsing, stale change details, runaway steppers, scrub a11y

### DIFF
--- a/.changeset/fix-review2-parser-react-a11y.md
+++ b/.changeset/fix-review2-parser-react-a11y.md
@@ -1,0 +1,55 @@
+---
+"raqam": minor
+---
+
+Fix ReDoS, RTL/scientific parsing, stale change details, runaway steppers, and scrub slider a11y
+
+A second full-source review surfaced a fresh set of defects (none overlapping the
+prior round). All fixes ship with regression tests.
+
+**Security**
+
+- Guard the parser against quadratic-backtracking ReDoS. The numeric-validation
+  regexes (core `parse`, and the scientific/compact `parseSpecialNotation` used on
+  paste) are rewritten without the ambiguous `(?:\d+\.?\d*|\.\d+)` alternation so
+  they match in linear time; `parse()` rejects inputs over 256 chars,
+  `parseSpecialNotation` over 256, and `handlePaste` discards clipboard text over
+  1000 chars before any scan. A long crafted paste can no longer freeze the main
+  thread.
+
+**Correctness**
+
+- RTL accounting currency negatives no longer parse as positive. `Intl` prepends
+  an invisible bidi mark before the `(` for locales like fa-IR; those marks are
+  now stripped before the accounting-paren match, so the negative sign survives
+  the format → parse round-trip.
+- The core `createParser` now parses scientific/exponent notation
+  (`"1.234E3" → 1234`, `"1e3" → 1000`, `"1.5e-3" → 0.0015`) instead of silently
+  dropping the exponent and producing a corrupt value; malformed exponents are
+  rejected rather than mangled.
+- `onValueChange` now reports the `formattedValue` that matches the emitted value.
+  It previously read display state one update stale (typing `5` reported `""`),
+  via a new synchronously-updated display mirror.
+- A custom `parseValue` is now honored on the typing and IME paths — its result is
+  threaded through to `numberValue` instead of being re-derived (and discarded) by
+  the built-in parser. Previously a non-invertible custom format produced the
+  wrong value while typing (the paste path was already correct).
+- Press-and-hold steppers no longer repeat forever when the button becomes
+  disabled mid-hold (value hits min/max): the repeat loop stops reactively on
+  disable, and new `onPointerCancel` / `onLostPointerCapture` handlers stop it on
+  touch interruption / pointer-capture loss.
+- Fullwidth CJK digits (U+FF10–U+FF19, emitted by full-width IMEs) are now
+  normalized to ASCII, so that input parses instead of being rejected.
+
+**Accessibility**
+
+- `<NumberField.ScrubArea>` (`role="slider"`) now exposes `aria-valuenow` /
+  `aria-valuemin` / `aria-valuemax` / `aria-valuetext` (and `aria-disabled`), so
+  assistive tech announces the current value and range and reflects arrow-key
+  scrubbing.
+
+**Maintainability**
+
+- The effective fraction-digit resolution is extracted into a single shared
+  helper (`resolveEffectiveFractions`) used by both the state and behavior hooks,
+  removing the hand-mirrored duplication that had to stay in sync.

--- a/docs/src/content/docs/api/advanced-primitives.mdx
+++ b/docs/src/content/docs/api/advanced-primitives.mdx
@@ -60,6 +60,12 @@ Options:
 | `interval` | `200` | Initial repeat interval; it accelerates down to a 50ms floor. |
 | `disabled` | `false` | Disables the handlers. |
 
+The returned handlers include `onPointerCancel` and `onLostPointerCapture` (in
+addition to `onPointerDown`/`onPointerUp`/`onPointerLeave`); spreading the whole
+object wires them all. The repeat loop also stops on its own the moment
+`disabled` flips to `true` mid-hold — important because a disabled `<button>`
+stops dispatching the pointer events that would otherwise clear it.
+
 ## `useScrubArea(state, options)`
 
 Pointer Lock powered drag-to-adjust behavior for custom scrub handles.
@@ -91,6 +97,12 @@ Return value:
 | `isScrubbing` | Whether pointer lock is active. |
 | `scrubAreaProps` | Props to spread onto the scrub handle element. |
 | `virtualCursor` | Pointer-lock cursor coordinates for custom overlays. |
+
+`scrubAreaProps` carries `role="slider"` plus the slider value ARIA —
+`aria-valuenow` (the current value), `aria-valuemin` / `aria-valuemax` (from the
+field's `minValue` / `maxValue`), `aria-valuetext` (the formatted display), and
+`aria-disabled` — so assistive tech announces the value and range and reflects
+arrow-key / drag updates. Spread the object as-is; don't drop these.
 
 ## `NumberFieldContext` / `useNumberFieldContext()`
 

--- a/docs/src/content/docs/api/components.mdx
+++ b/docs/src/content/docs/api/components.mdx
@@ -175,9 +175,12 @@ Wraps any element; dragging over it adjusts the value via Pointer Lock API.
 ```
 
 The element renders as `role="slider"` with `tabIndex={0}`, so it is keyboard
-accessible: arrow keys (←/→ or ↑/↓) step the value while it is focused. The CSS
-`cursor` reflects the axis (`ew-resize` / `ns-resize` / `move`), and
-`data-scrubbing=""` is set while a pointer-lock drag is active.
+accessible: arrow keys (←/→ or ↑/↓) step the value while it is focused. It also
+exposes the slider value ARIA — `aria-valuenow`, `aria-valuemin`,
+`aria-valuemax`, `aria-valuetext` (the formatted value), and `aria-disabled` — so
+assistive tech announces the current value and range. The CSS `cursor` reflects
+the axis (`ew-resize` / `ns-resize` / `move`), and `data-scrubbing=""` is set
+while a pointer-lock drag is active.
 
 `pixelSensitivity` values below `1` are clamped to `1`.
 

--- a/docs/src/content/docs/api/core-utilities.mdx
+++ b/docs/src/content/docs/api/core-utilities.mdx
@@ -94,15 +94,19 @@ logic.
 Add support for another digit block.
 
 ```ts
+// Gujarati digits ૦–૯ (U+0AE6–U+0AEF) — not a built-in block.
 registerLocale({
-  digitBlocks: [[0xff10, 0xff19]],
+  digitBlocks: [[0x0ae6, 0x0aef]],
 });
 
-normalizeDigits("１２３");
+normalizeDigits("૧૨૩");
 // "123"
 ```
 
-Use this only for scripts not already covered by the built-in locale plugins.
+Use this only for scripts not already covered by the built-ins. The built-in
+blocks are Arabic-Indic, Extended Arabic-Indic (Persian), Devanagari, Bengali,
+Thai, and fullwidth (U+FF10–U+FF19, emitted by full-width CJK IMEs) — these are
+normalized out of the box, no `registerLocale` needed.
 For Persian, Arabic, Hindi, Bengali, and Thai, prefer the ready-made modules in
 `raqam/locales/*`.
 

--- a/src/core/formatter.ts
+++ b/src/core/formatter.ts
@@ -82,6 +82,31 @@ function extractLocaleInfo(
   return { decimalSeparator, groupingSeparator, minusSign, zero, isRTL };
 }
 
+/**
+ * Resolve the effective fraction-digit settings for a field. When decimals are
+ * disallowed, fraction padding/scale is forced to 0 so currency /
+ * fixedDecimalScale never pad ".00" (which the dot-strip would then re-read,
+ * exploding the value). Shared by useNumberFieldState and useNumberField so the
+ * editable display and the on-commit display stay in lockstep.
+ */
+export function resolveEffectiveFractions(opts: {
+  allowDecimal?: boolean;
+  minimumFractionDigits?: number;
+  maximumFractionDigits?: number;
+  fixedDecimalScale?: boolean;
+}): {
+  effMinFrac: number | undefined;
+  effMaxFrac: number | undefined;
+  effFixedScale: boolean | undefined;
+} {
+  const allowDecimal = opts.allowDecimal ?? true;
+  return {
+    effMinFrac: allowDecimal ? opts.minimumFractionDigits : 0,
+    effMaxFrac: allowDecimal ? opts.maximumFractionDigits : 0,
+    effFixedScale: allowDecimal ? opts.fixedDecimalScale : false,
+  };
+}
+
 // ── Factory ───────────────────────────────────────────────────────────────────
 
 export interface FormatterOptions {

--- a/src/core/normalizer.test.ts
+++ b/src/core/normalizer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { normalizeDigits, isNonLatinDigit, registerLocale } from "./normalizer.js";
+import { createParser } from "./parser.js";
 
 describe("normalizeDigits", () => {
   it("passes ASCII digits through unchanged", () => {
@@ -48,6 +49,11 @@ describe("normalizeDigits", () => {
   it("handles mixed Persian and ASCII", () => {
     expect(normalizeDigits("۱2۳")).toBe("123");
   });
+
+  it("converts fullwidth CJK digits", () => {
+    // U+FF11 U+FF12 U+FF13 — fullwidth one/two/three
+    expect(normalizeDigits("１２３")).toBe("123");
+  });
 });
 
 describe("isNonLatinDigit", () => {
@@ -67,6 +73,16 @@ describe("isNonLatinDigit", () => {
   it("returns false for letters", () => {
     expect(isNonLatinDigit("a")).toBe(false);
     expect(isNonLatinDigit("ض")).toBe(false);
+  });
+
+  it("returns true for fullwidth CJK digit", () => {
+    expect(isNonLatinDigit("５")).toBe(true);
+  });
+});
+
+describe("fullwidth CJK digits — parsing", () => {
+  it("parses a ja-JP fullwidth digit string", () => {
+    expect(createParser({ locale: "ja-JP" }).parse("１２３").value).toBe(123);
   });
 });
 

--- a/src/core/normalizer.ts
+++ b/src/core/normalizer.ts
@@ -10,6 +10,7 @@ const BUILTIN_DIGIT_BLOCKS: DigitBlock[] = [
   [0x0966, 0x096f], // Devanagari / Hindi (deva)
   [0x09e6, 0x09ef], // Bengali (beng)
   [0x0e50, 0x0e59], // Thai (thai)
+  [0xff10, 0xff19], // Fullwidth (CJK IMEs emit these in full-width mode)
 ];
 
 // Mutable registry — locale plugins can add blocks here

--- a/src/core/parser.test.ts
+++ b/src/core/parser.test.ts
@@ -271,6 +271,19 @@ describe("createParser — scientific notation", () => {
     expect(createParser({ locale: "en-US" }).parse("1e2e3").value).toBeNull();
   });
 
+  it("normalizes localized scientific exponent separators (ar/fa/sv)", () => {
+    for (const locale of ["fa-IR", "ar-EG", "sv-SE"]) {
+      const opts = {
+        locale,
+        formatOptions: { notation: "scientific" } as Intl.NumberFormatOptions,
+      };
+      const f = createFormatter(opts);
+      const p = createParser(opts);
+      expect(p.parse(f.format(1234)).value).toBe(1234);
+      expect(p.parse(f.format(-1234)).value).toBe(-1234);
+    }
+  });
+
   it("accepts a complete exponent with a non-digit trailing affordance, rejects junk/markers", () => {
     const p = createParser({ locale: "en-US" });
     expect(p.parse("1e3 km").value).toBe(1000); // trailing unit-like affordance dropped

--- a/src/core/parser.test.ts
+++ b/src/core/parser.test.ts
@@ -226,4 +226,15 @@ describe("createParser — scientific notation", () => {
     expect(p.parse("1e-3").value).toBeNull(); // 0.001 is fractional → rejected
     expect(p.parse("1e3").value).toBe(1000); // integer → allowed
   });
+
+  it("rejects malformed exponents instead of mis-parsing them as the mantissa", () => {
+    const p = createParser({ locale: "en-US" });
+    // Previously these char-stripped the "e" and silently became 1.
+    expect(p.parse("1e+").value).toBeNull();
+    expect(p.parse("1efoo").value).toBeNull();
+    expect(p.parse("1e").value).toBeNull();
+    expect(p.parse("1e2e3").value).toBeNull();
+    // The well-formed form still parses.
+    expect(p.parse("1e3").value).toBe(1000);
+  });
 });

--- a/src/core/parser.test.ts
+++ b/src/core/parser.test.ts
@@ -284,6 +284,19 @@ describe("createParser — scientific notation", () => {
     }
   });
 
+  it("accepts a leading + in scientific notation (signDisplay always/exceptZero)", () => {
+    const opts = {
+      locale: "en-US",
+      formatOptions: { notation: "scientific", signDisplay: "always" } as Intl.NumberFormatOptions,
+    };
+    const f = createFormatter(opts);
+    const p = createParser(opts);
+    expect(p.parse(f.format(1234)).value).toBe(1234); // "+1.234E3"
+    expect(p.parse(f.format(-1234)).value).toBe(-1234);
+    // a typed leading "+" is also accepted
+    expect(createParser({ locale: "en-US" }).parse("+1e3").value).toBe(1000);
+  });
+
   it("accepts a complete exponent with a non-digit trailing affordance, rejects junk/markers", () => {
     const p = createParser({ locale: "en-US" });
     expect(p.parse("1e3 km").value).toBe(1000); // trailing unit-like affordance dropped

--- a/src/core/parser.test.ts
+++ b/src/core/parser.test.ts
@@ -237,4 +237,13 @@ describe("createParser — scientific notation", () => {
     // The well-formed form still parses.
     expect(p.parse("1e3").value).toBe(1000);
   });
+
+  it("parses an exponent with surrounding whitespace", () => {
+    const p = createParser({ locale: "en-US" });
+    expect(p.parse(" 1e3 ").value).toBe(1000);
+    expect(p.parse("\t1.5e-3\n").value).toBe(0.0015);
+    // Trimming is surrounding-only: a digit then a space then an "e"-word is NOT
+    // a malformed exponent — it strips to the leading number.
+    expect(p.parse("1.5 each").value).toBe(1.5);
+  });
 });

--- a/src/core/parser.test.ts
+++ b/src/core/parser.test.ts
@@ -153,3 +153,77 @@ describe("createParser — accounting format (parentheses = negative)", () => {
     expect(parser.parse(formatted).value).toBe(-1234.56);
   });
 });
+
+describe("createParser — ReDoS / input length cap", () => {
+  const parser = createParser({ locale: "en-US" });
+
+  it("rejects inputs longer than 256 chars", () => {
+    expect(parser.parse("9".repeat(300))).toEqual({
+      value: null,
+      isValid: false,
+      isIntermediate: false,
+    });
+  });
+
+  it("rejects a long pathological multi-dot string and stays fast", () => {
+    const pathological = "9".repeat(50000) + "." + "9".repeat(50000) + ".";
+    const start = Date.now();
+    const r = parser.parse(pathological);
+    expect(r.value).toBeNull();
+    expect(r.isValid).toBe(false);
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+
+  it("still parses a normal ≤256-char number", () => {
+    expect(Number.isFinite(parser.parse("9".repeat(40)).value as number)).toBe(true);
+  });
+});
+
+describe("createParser — RTL accounting sign (bidi-mark fix)", () => {
+  const opts = {
+    locale: "fa-IR",
+    formatOptions: {
+      style: "currency" as const,
+      currency: "IRR",
+      currencySign: "accounting" as const,
+    },
+  };
+  const parser = createParser(opts);
+  const fmt = createFormatter(opts);
+
+  it("preserves the negative sign through a format/parse round-trip", () => {
+    expect(parser.parse(fmt.format(-1234)).value).toBe(-1234);
+  });
+
+  it("round-trips a positive value", () => {
+    expect(parser.parse(fmt.format(1234)).value).toBe(1234);
+  });
+});
+
+describe("createParser — scientific notation", () => {
+  const parser = createParser({ locale: "en-US" });
+
+  it("parses uppercase exponent", () => {
+    expect(parser.parse("1.234E3").value).toBe(1234);
+  });
+
+  it("parses integer mantissa exponent", () => {
+    expect(parser.parse("1e3").value).toBe(1000);
+  });
+
+  it("parses negative exponent", () => {
+    expect(parser.parse("1.5e-3").value).toBe(0.0015);
+  });
+
+  it("round-trips a scientific-notation formatted value", () => {
+    const fmt = createFormatter({ locale: "en-US", formatOptions: { notation: "scientific" } });
+    expect(parser.parse(fmt.format(1234)).value).toBe(1234);
+  });
+
+  it("rejects a fractional exponent value when decimals are disallowed", () => {
+    const p = createParser({ locale: "en-US", allowDecimal: false });
+    expect(p.parse("5e-1").value).toBeNull(); // 0.5 is fractional → rejected
+    expect(p.parse("1e-3").value).toBeNull(); // 0.001 is fractional → rejected
+    expect(p.parse("1e3").value).toBe(1000); // integer → allowed
+  });
+});

--- a/src/core/parser.test.ts
+++ b/src/core/parser.test.ts
@@ -246,4 +246,35 @@ describe("createParser — scientific notation", () => {
     // a malformed exponent — it strips to the leading number.
     expect(p.parse("1.5 each").value).toBe(1.5);
   });
+
+  it("parses scientific/engineering percent values (e.g. \"5E1%\")", () => {
+    const sci = {
+      locale: "en-US",
+      formatOptions: { style: "percent", notation: "scientific" } as Intl.NumberFormatOptions,
+    };
+    const p = createParser(sci);
+    expect(p.parse("5E1%").value).toBe(0.5);
+    expect(p.parse("5E0%").value).toBe(0.05);
+    expect(p.parse("-5E1%").value).toBe(-0.5);
+    // round-trips through the formatter
+    expect(p.parse(createFormatter(sci).format(0.5)).value).toBe(0.5);
+    // engineering notation too
+    const pe = createParser({
+      locale: "en-US",
+      formatOptions: { style: "percent", notation: "engineering" },
+    });
+    expect(pe.parse("150E0%").value).toBe(1.5);
+    // regular percent + malformed-exponent rejection remain unaffected
+    expect(
+      createParser({ locale: "en-US", formatOptions: { style: "percent" } }).parse("50%").value
+    ).toBe(0.5);
+    expect(createParser({ locale: "en-US" }).parse("1e2e3").value).toBeNull();
+  });
+
+  it("accepts a complete exponent with a non-digit trailing affordance, rejects digit junk", () => {
+    const p = createParser({ locale: "en-US" });
+    expect(p.parse("1e3 km").value).toBe(1000); // trailing unit-like affordance dropped
+    expect(p.parse("1e3%").value).toBe(1000); // trailing sign dropped (non-percent field)
+    expect(p.parse("1e3e4").value).toBeNull(); // remainder has a digit → not a clean exponent
+  });
 });

--- a/src/core/parser.test.ts
+++ b/src/core/parser.test.ts
@@ -271,10 +271,16 @@ describe("createParser — scientific notation", () => {
     expect(createParser({ locale: "en-US" }).parse("1e2e3").value).toBeNull();
   });
 
-  it("accepts a complete exponent with a non-digit trailing affordance, rejects digit junk", () => {
+  it("accepts a complete exponent with a non-digit trailing affordance, rejects junk/markers", () => {
     const p = createParser({ locale: "en-US" });
     expect(p.parse("1e3 km").value).toBe(1000); // trailing unit-like affordance dropped
     expect(p.parse("1e3%").value).toBe(1000); // trailing sign dropped (non-percent field)
+    expect(p.parse("1e3 meters").value).toBe(1000); // affordance may contain "e"
     expect(p.parse("1e3e4").value).toBeNull(); // remainder has a digit → not a clean exponent
+    // remainder starting with an exponent-syntax char is a malformed exponent
+    expect(p.parse("1e3e").value).toBeNull();
+    expect(p.parse("1e3E").value).toBeNull();
+    expect(p.parse("1e3+").value).toBeNull();
+    expect(p.parse("1e3-").value).toBeNull();
   });
 });

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -146,13 +146,20 @@ export function createParser(opts: ParserOptions = {}): Parser {
       s = s.split("−").join("-");
     }
 
+    // Run the exponent checks on a copy with surrounding whitespace removed —
+    // the regexes are anchored, so " 1e3 " would otherwise miss and get its "E"
+    // char-stripped to "13". Only leading/trailing spaces are trimmed (not
+    // internal ones), so "1.5 each" stays a space-separated word, not "1.5each"
+    // (which would look like a malformed exponent).
+    const st = s.trim();
+
     // 7a. Preserve a clean trailing exponent (e.g. "1.234E3") so scientific
     // notation round-trips through parse(): the generic char-strip below would
     // delete the "E", gluing mantissa and exponent into a wrong finite value
     // ("1.234E3" -> "1.2343"). Returns early so the minus-collapse (step 8) does
     // not strip a negative exponent's sign. The mantissa carries at most one
     // leading "-", so no collapse is needed.
-    const sci = s.match(/^(-?(?:\d+(?:\.\d*)?|\.\d+))[eE]([+-]?\d+)$/);
+    const sci = st.match(/^(-?(?:\d+(?:\.\d*)?|\.\d+))[eE]([+-]?\d+)$/);
     if (sci) {
       return `${sci[1]}e${sci[2]}`;
     }
@@ -162,8 +169,8 @@ export function createParser(opts: ParserOptions = {}): Parser {
     // The strip below would silently delete the "e" and yield a wrong value (1),
     // so return the string with the marker intact — parse()'s exponent branch
     // then rejects it instead of mis-parsing.
-    if (/^[+-]?(?:\d+(?:\.\d*)?|\.\d+)[eE]/.test(s)) {
-      return s;
+    if (/^[+-]?(?:\d+(?:\.\d*)?|\.\d+)[eE]/.test(st)) {
+      return st;
     }
 
     // 7. Strip currency symbol, percent sign, spaces that Intl might prepend/append

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -2,6 +2,9 @@ import { createFormatter } from "./formatter.js";
 import { normalizeDigits } from "./normalizer.js";
 import type { LocaleInfo, ParseResult } from "./types.js";
 
+/** Upper bound on input length accepted by parse(); see the guard in parse(). */
+const MAX_PARSE_INPUT = 256;
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /**
@@ -95,6 +98,12 @@ export function createParser(opts: ParserOptions = {}): Parser {
     // 1. Normalise non-Latin digits to ASCII
     let s = normalizeDigits(raw);
 
+    // 1a. Strip Unicode bidi control marks. RTL locales' accounting currency
+    // format prepends an invisible LRM/RLM (e.g. fa-IR: "‎(ریال ۱٬۲۳۴)") before
+    // the "(", which would defeat the index-0-anchored accounting match below and
+    // silently drop the negative sign.
+    s = s.replace(/[‎‏؜‪-‮⁦-⁩]/g, "");
+
     // 1b. Remove the currency symbol wholesale (before separators are touched),
     // so a symbol containing ASCII dots — e.g. Arabic "ج.م." — does not leave
     // stray "." that the numeric validation would reject.
@@ -137,6 +146,17 @@ export function createParser(opts: ParserOptions = {}): Parser {
       s = s.split("−").join("-");
     }
 
+    // 7a. Preserve a clean trailing exponent (e.g. "1.234E3") so scientific
+    // notation round-trips through parse(): the generic char-strip below would
+    // delete the "E", gluing mantissa and exponent into a wrong finite value
+    // ("1.234E3" -> "1.2343"). Returns early so the minus-collapse (step 8) does
+    // not strip a negative exponent's sign. The mantissa carries at most one
+    // leading "-", so no collapse is needed.
+    const sci = s.match(/^(-?(?:\d+(?:\.\d*)?|\.\d+))[eE]([+-]?\d+)$/);
+    if (sci) {
+      return `${sci[1]}e${sci[2]}`;
+    }
+
     // 7. Strip currency symbol, percent sign, spaces that Intl might prepend/append
     // Strip any remaining non-numeric chars except digits, ".", "-"
     // (handles currency prefixes/suffixes from Intl)
@@ -155,6 +175,14 @@ export function createParser(opts: ParserOptions = {}): Parser {
 
   function parse(input: string): ParseResult {
     if (!input || input.trim() === "") {
+      return { value: null, isValid: false, isIntermediate: false };
+    }
+
+    // Bound the input length before any regex/scan work. Real numeric input is
+    // short; an unbounded attacker-controlled string (e.g. a crafted paste)
+    // could otherwise drive worst-case backtracking. 256 chars is far beyond any
+    // legitimate number (≈250-digit precision) yet keeps all scans trivial.
+    if (input.length > MAX_PARSE_INPUT) {
       return { value: null, isValid: false, isIntermediate: false };
     }
 
@@ -188,9 +216,34 @@ export function createParser(opts: ParserOptions = {}): Parser {
       return { value: null, isValid: false, isIntermediate: false };
     }
 
+    // Scientific / exponent notation, preserved by stripAffordances (step 7a).
+    // Handle it explicitly: Number() reads it, but the plain validation regex
+    // below would reject the "e". A malformed exponent is rejected rather than
+    // silently corrupted.
+    if (/[eE]/.test(stripped)) {
+      if (!/^-?(?:\d+(?:\.\d*)?|\.\d+)[eE][+-]?\d+$/.test(stripped)) {
+        return { value: null, isValid: false, isIntermediate: false };
+      }
+      let n = Number(stripped);
+      if (!Number.isFinite(n)) {
+        return { value: null, isValid: false, isIntermediate: false };
+      }
+      // A fractional exponent value (e.g. "5e-1" = 0.5) has no literal "." to
+      // trip the allowDecimal guard above, so reject it here for parity with the
+      // plain-decimal path when decimals are disallowed.
+      if (!allowDecimal && !Number.isInteger(n)) {
+        return { value: null, isValid: false, isIntermediate: false };
+      }
+      if (Object.is(n, -0)) n = 0;
+      if (isPercent && n !== 0) n = Number((n / 100).toPrecision(15));
+      return { value: n, isValid: true, isIntermediate: false };
+    }
+
     // Accept integers and decimals with the dot either trailing ("1.") or
-    // leading (".5") so partially-typed values still yield a numeric value.
-    if (!/^-?(?:\d+\.?\d*|\.\d+)$/.test(stripped)) {
+    // leading (".5") so partially-typed values still yield a numeric value. The
+    // pattern is written without an ambiguous alternation so it matches in linear
+    // time (the empty / lone-"-" / lone-"." cases are handled above).
+    if (!/^-?\d*(?:\.\d*)?$/.test(stripped)) {
       return { value: null, isValid: false, isIntermediate: false };
     }
 

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -195,7 +195,10 @@ export function createParser(opts: ParserOptions = {}): Parser {
     // malformed/continued exponents that must fall through to the guard / strip.
     // Returning early also skips the minus-collapse (step 8) so a negative
     // exponent's sign survives; the mantissa carries at most one leading "-".
-    const sci = st.match(/^(-?(?:\d+(?:\.\d*)?|\.\d+))[eE]([+-]?\d+)(.*)$/);
+    // The mantissa allows a leading "+" too: signDisplay "always"/"exceptZero"
+    // formats positives as "+1.234E3"; Number() accepts the "+" and the regular
+    // path already tolerates a leading "+" (the strip removes it).
+    const sci = st.match(/^([+-]?(?:\d+(?:\.\d*)?|\.\d+))[eE]([+-]?\d+)(.*)$/);
     if (sci && !/\d/.test(sci[3]) && !/^[eE+\-]/.test(sci[3])) {
       return `${sci[1]}e${sci[2]}`;
     }
@@ -273,7 +276,7 @@ export function createParser(opts: ParserOptions = {}): Parser {
     // below would reject the "e". A malformed exponent is rejected rather than
     // silently corrupted.
     if (/[eE]/.test(stripped)) {
-      if (!/^-?(?:\d+(?:\.\d*)?|\.\d+)[eE][+-]?\d+$/.test(stripped)) {
+      if (!/^[+-]?(?:\d+(?:\.\d*)?|\.\d+)[eE][+-]?\d+$/.test(stripped)) {
         return { value: null, isValid: false, isIntermediate: false };
       }
       let n = Number(stripped);

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -88,6 +88,29 @@ export function createParser(opts: ParserOptions = {}): Parser {
     }
   }
 
+  // Locale's scientific/engineering exponent separator. Most locales use "E"
+  // (handled directly by the exponent regex), but some localize it — ar "أس",
+  // fa "×۱۰^", sv "×10^". Captured (digit-normalized) so it can be mapped to "e"
+  // before exponent handling; otherwise the generic strip would delete it and
+  // glue the exponent digits onto the mantissa ("1.234×10^3" -> "1.234103").
+  let exponentSeparator = "";
+  const notation = opts.formatOptions?.notation;
+  if (notation === "scientific" || notation === "engineering") {
+    try {
+      const sep = normalizeDigits(
+        fmt
+          .formatToParts(1234)
+          .filter((p) => p.type === "exponentSeparator")
+          .map((p) => p.value)
+          .join("")
+      );
+      // Plain ASCII "E"/"e" is already handled by the exponent regex.
+      if (sep && sep !== "e" && sep !== "E") exponentSeparator = sep;
+    } catch {
+      exponentSeparator = "";
+    }
+  }
+
   function getLocaleInfo(): LocaleInfo {
     return fmt.getLocaleInfo();
   }
@@ -103,6 +126,13 @@ export function createParser(opts: ParserOptions = {}): Parser {
     // the "(", which would defeat the index-0-anchored accounting match below and
     // silently drop the negative sign.
     s = s.replace(/[‎‏؜‪-‮⁦-⁩]/g, "");
+
+    // 1a2. Map a localized scientific exponent separator (ar "أس", fa "×۱۰^",
+    // sv "×10^") to "e" so the exponent handling below recognizes it instead of
+    // the generic strip mangling it ("1.234×10^3" -> "1.234103").
+    if (exponentSeparator) {
+      s = s.split(exponentSeparator).join("e");
+    }
 
     // 1b. Remove the currency symbol wholesale (before separators are touched),
     // so a symbol containing ASCII dots — e.g. Arabic "ج.م." — does not leave

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -157,14 +157,16 @@ export function createParser(opts: ParserOptions = {}): Parser {
     // notation round-trips through parse(): the generic char-strip below would
     // delete the "E", gluing mantissa and exponent into a wrong value
     // ("1.234E3" -> "1.2343"). A complete exponent may be followed by trailing
-    // affordances that carry no further digits — a percent sign ("5E1%"), a unit
-    // (" km"), etc. — which are dropped here (parse() re-applies percent scaling
-    // via isPercent). A digit in the remainder means it is NOT a clean exponent
-    // (e.g. "1e2e3"), so fall through to the malformed guard / strip. Returning
-    // early also skips the minus-collapse (step 8) so a negative exponent's sign
-    // survives; the mantissa carries at most one leading "-".
+    // affordances — a percent sign ("5E1%"), a unit (" km", " meters"), etc. —
+    // which are dropped here (parse() re-applies percent scaling via isPercent).
+    // The remainder is only treated as an affordance when it carries no further
+    // digit AND does not start with an exponent-syntax char (e/E/+/-): a real
+    // affordance never starts with one, whereas "1e3e", "1e3+", "1e2e3" are
+    // malformed/continued exponents that must fall through to the guard / strip.
+    // Returning early also skips the minus-collapse (step 8) so a negative
+    // exponent's sign survives; the mantissa carries at most one leading "-".
     const sci = st.match(/^(-?(?:\d+(?:\.\d*)?|\.\d+))[eE]([+-]?\d+)(.*)$/);
-    if (sci && !/\d/.test(sci[3])) {
+    if (sci && !/\d/.test(sci[3]) && !/^[eE+\-]/.test(sci[3])) {
       return `${sci[1]}e${sci[2]}`;
     }
 

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -146,21 +146,25 @@ export function createParser(opts: ParserOptions = {}): Parser {
       s = s.split("−").join("-");
     }
 
-    // Run the exponent checks on a copy with surrounding whitespace removed —
-    // the regexes are anchored, so " 1e3 " would otherwise miss and get its "E"
+    // Run the exponent checks on a copy with surrounding whitespace removed — the
+    // regexes are anchored, so " 1e3 " would otherwise miss and get its "E"
     // char-stripped to "13". Only leading/trailing spaces are trimmed (not
     // internal ones), so "1.5 each" stays a space-separated word, not "1.5each"
     // (which would look like a malformed exponent).
     const st = s.trim();
 
-    // 7a. Preserve a clean trailing exponent (e.g. "1.234E3") so scientific
+    // 7a. Preserve a clean exponent (e.g. "1.234E3") so scientific/engineering
     // notation round-trips through parse(): the generic char-strip below would
-    // delete the "E", gluing mantissa and exponent into a wrong finite value
-    // ("1.234E3" -> "1.2343"). Returns early so the minus-collapse (step 8) does
-    // not strip a negative exponent's sign. The mantissa carries at most one
-    // leading "-", so no collapse is needed.
-    const sci = st.match(/^(-?(?:\d+(?:\.\d*)?|\.\d+))[eE]([+-]?\d+)$/);
-    if (sci) {
+    // delete the "E", gluing mantissa and exponent into a wrong value
+    // ("1.234E3" -> "1.2343"). A complete exponent may be followed by trailing
+    // affordances that carry no further digits — a percent sign ("5E1%"), a unit
+    // (" km"), etc. — which are dropped here (parse() re-applies percent scaling
+    // via isPercent). A digit in the remainder means it is NOT a clean exponent
+    // (e.g. "1e2e3"), so fall through to the malformed guard / strip. Returning
+    // early also skips the minus-collapse (step 8) so a negative exponent's sign
+    // survives; the mantissa carries at most one leading "-".
+    const sci = st.match(/^(-?(?:\d+(?:\.\d*)?|\.\d+))[eE]([+-]?\d+)(.*)$/);
+    if (sci && !/\d/.test(sci[3])) {
       return `${sci[1]}e${sci[2]}`;
     }
 

--- a/src/core/parser.ts
+++ b/src/core/parser.ts
@@ -157,6 +157,15 @@ export function createParser(opts: ParserOptions = {}): Parser {
       return `${sci[1]}e${sci[2]}`;
     }
 
+    // 7b. MALFORMED exponent: a valid mantissa immediately followed by "e"/"E"
+    // that is not a complete scientific number ("1e", "1e+", "1efoo", "1EUR").
+    // The strip below would silently delete the "e" and yield a wrong value (1),
+    // so return the string with the marker intact — parse()'s exponent branch
+    // then rejects it instead of mis-parsing.
+    if (/^[+-]?(?:\d+(?:\.\d*)?|\.\d+)[eE]/.test(s)) {
+      return s;
+    }
+
     // 7. Strip currency symbol, percent sign, spaces that Intl might prepend/append
     // Strip any remaining non-numeric chars except digits, ".", "-"
     // (handles currency prefixes/suffixes from Intl)

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -159,6 +159,13 @@ export interface NumberFieldState {
   /** Internal: read the current change reason (used by NumberField.Root) */
   _getLastChangeReason: () => ChangeReason;
   /**
+   * Internal: read the display string that matches the value most recently
+   * emitted via onChange. Updated synchronously before the state setter, so it is
+   * accurate at onChange time (unlike `inputValue`, which still reflects the
+   * previous render). Used by NumberField.Root to report `formattedValue`.
+   */
+  _getLatestDisplay: () => string;
+  /**
    * Update display string (triggers parse + onChange). `knownValue` overrides
    * the parsed value when `val` is a formatted string that cannot be reversed
    * (compact "2.5K", scientific, unit notation).

--- a/src/react/NumberField.test.tsx
+++ b/src/react/NumberField.test.tsx
@@ -923,3 +923,160 @@ describe("custom formatValue/parseValue", () => {
     expect((screen.getByTestId("input") as HTMLInputElement).value).toBe("1234.00 pts");
   });
 });
+
+describe("NumberField onValueChange formattedValue", () => {
+  it("reports the correct formattedValue while typing", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(
+      <NumberField.Root locale="en-US" onValueChange={onValueChange}>
+        <NumberField.Input data-testid="input" />
+      </NumberField.Root>
+    );
+    const input = screen.getByTestId("input");
+    await user.click(input);
+    await user.type(input, "5");
+
+    expect(onValueChange).toHaveBeenCalled();
+    const calls = onValueChange.mock.calls;
+    const [value, details] = calls[calls.length - 1] as [
+      number | null,
+      { reason: string; formattedValue: string },
+    ];
+    expect(value).toBe(5);
+    expect(details).toEqual(expect.objectContaining({ formattedValue: "5" }));
+  });
+
+  it("reports the correct formattedValue on ArrowUp", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(
+      <NumberField.Root
+        locale="en-US"
+        defaultValue={5}
+        step={1}
+        onValueChange={onValueChange}
+      >
+        <NumberField.Input data-testid="input" />
+      </NumberField.Root>
+    );
+    const input = screen.getByTestId("input");
+    await user.click(input);
+    await user.keyboard("{ArrowUp}");
+
+    expect(onValueChange).toHaveBeenCalled();
+    const calls = onValueChange.mock.calls;
+    const [value, details] = calls[calls.length - 1] as [
+      number | null,
+      { reason: string; formattedValue: string },
+    ];
+    expect(value).toBe(6);
+    expect(details).toEqual(
+      expect.objectContaining({ reason: "keyboard", formattedValue: "6" })
+    );
+  });
+});
+
+describe("NumberField custom parseValue while typing", () => {
+  it("honors a custom parseValue/formatValue (k-suffix) when typing", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(
+      <NumberField.Root
+        locale="en-US"
+        onValueChange={onValueChange}
+        parseValue={(s) => ({
+          value: s.endsWith("k")
+            ? parseFloat(s) * 1000
+            : /\d/.test(s)
+              ? parseFloat(s)
+              : null,
+          isIntermediate: false,
+        })}
+        formatValue={(v) => (v >= 1000 ? `${v / 1000}k` : String(v))}
+      >
+        <NumberField.Input data-testid="input" />
+      </NumberField.Root>
+    );
+    const input = screen.getByTestId("input") as HTMLInputElement;
+    await user.click(input);
+    await user.type(input, "5000");
+
+    // The custom formatter renders 5000 → "5k".
+    expect(input.value).toBe("5k");
+    // The custom parser's value (5000) must be threaded through — NOT 5.
+    expect(onValueChange).toHaveBeenCalled();
+    const calls = onValueChange.mock.calls;
+    const [value] = calls[calls.length - 1] as [number | null, unknown];
+    expect(value).toBe(5000);
+  });
+});
+
+describe("NumberField cut behavior", () => {
+  it("uses raw numberValue and clears the field when copyBehavior='raw'", () => {
+    const onValueChange = vi.fn();
+    render(
+      <NumberField.Root
+        locale="en-US"
+        defaultValue={1234.56}
+        copyBehavior="raw"
+        onValueChange={onValueChange}
+      >
+        <NumberField.Input data-testid="input" />
+      </NumberField.Root>
+    );
+    const input = screen.getByTestId("input") as HTMLInputElement;
+    const mockSetData = vi.fn();
+    const mockGetData = vi.fn(() => "");
+
+    fireEvent.cut(input, {
+      clipboardData: { setData: mockSetData, getData: mockGetData },
+    });
+
+    // Raw numeric string is written to the clipboard.
+    expect(mockSetData).toHaveBeenCalledWith("text/plain", "1234.56");
+    // The field is cleared after cut.
+    expect(input.value).toBe("");
+    // onValueChange reports the dedicated "clear" reason with a null value.
+    expect(onValueChange).toHaveBeenCalledWith(
+      null,
+      expect.objectContaining({ reason: "clear" })
+    );
+  });
+});
+
+describe("IME compositionEnd value processing", () => {
+  it("fa-IR: processes the composed value and formats it with the fa grouping separator", () => {
+    render(
+      <NumberField.Root locale="fa-IR">
+        <NumberField.Input data-testid="input" />
+      </NumberField.Root>
+    );
+    const input = screen.getByTestId("input") as HTMLInputElement;
+    fireEvent.compositionStart(input);
+    fireEvent.compositionEnd(input, { target: { value: "۱۲۳۴" } });
+
+    // fa digits with the fa grouping separator U+066C.
+    expect(input.value).toBe("۱٬۲۳۴");
+  });
+
+  it("custom parse/format: processes the composed value through the custom branch", () => {
+    render(
+      <NumberField.Root
+        locale="en-US"
+        parseValue={(s) => ({
+          value: /\d/.test(s) ? parseFloat(s) : null,
+          isIntermediate: false,
+        })}
+        formatValue={(v) => `${v} pts`}
+      >
+        <NumberField.Input data-testid="input" />
+      </NumberField.Root>
+    );
+    const input = screen.getByTestId("input") as HTMLInputElement;
+    fireEvent.compositionStart(input);
+    fireEvent.compositionEnd(input, { target: { value: "42" } });
+
+    expect(input.value).toBe("42 pts");
+  });
+});

--- a/src/react/NumberField.test.tsx
+++ b/src/react/NumberField.test.tsx
@@ -1010,6 +1010,31 @@ describe("NumberField custom parseValue while typing", () => {
     const [value] = calls[calls.length - 1] as [number | null, unknown];
     expect(value).toBe(5000);
   });
+
+  it("honors a custom parseValue that rejects input (value: null)", async () => {
+    const user = userEvent.setup();
+    const onValueChange = vi.fn();
+    render(
+      <NumberField.Root
+        locale="en-US"
+        onValueChange={onValueChange}
+        // Rejects "5" specifically; the built-in parser would otherwise read it as 5.
+        parseValue={(s) => ({
+          value: s === "5" ? null : /\d/.test(s) ? parseFloat(s) : null,
+          isIntermediate: false,
+        })}
+      >
+        <NumberField.Input data-testid="input" />
+      </NumberField.Root>
+    );
+    const input = screen.getByTestId("input") as HTMLInputElement;
+    await user.click(input);
+    await user.type(input, "5");
+    // The custom rejection must win — numberValue stays null, not re-parsed to 5.
+    const calls = onValueChange.mock.calls;
+    const [value] = calls[calls.length - 1] as [number | null, unknown];
+    expect(value).toBeNull();
+  });
 });
 
 describe("NumberField cut behavior", () => {

--- a/src/react/NumberField.tsx
+++ b/src/react/NumberField.tsx
@@ -190,7 +190,10 @@ const Root = forwardRef<HTMLDivElement, NumberFieldRootProps>(function NumberFie
       if (onValueChangeRef.current && stateRef.current) {
         onValueChangeRef.current(value, {
           reason: stateRef.current._getLastChangeReason(),
-          formattedValue: stateRef.current.inputValue,
+          // _getLatestDisplay (not .inputValue) — at onChange time `inputValue`
+          // state still holds the previous render's value; the ref is updated
+          // synchronously before the emission, so it matches `value`.
+          formattedValue: stateRef.current._getLatestDisplay(),
         });
       }
     },

--- a/src/react/ScrubArea.test.tsx
+++ b/src/react/ScrubArea.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { NumberField } from "./NumberField.js";
 
@@ -268,5 +268,87 @@ describe("NumberField.ScrubArea", () => {
       </NumberField.Root>
     );
     expect(screen.getByTestId("scrub-area")).toHaveAttribute("aria-label", "Glisser pour changer");
+  });
+
+  it("exposes slider value/range ARIA", async () => {
+    render(
+      <NumberField.Root defaultValue={50} minValue={0} maxValue={100}>
+        <NumberField.ScrubArea data-testid="scrub">Drag</NumberField.ScrubArea>
+        <NumberField.Input />
+      </NumberField.Root>
+    );
+
+    const scrub = screen.getByTestId("scrub");
+    expect(scrub).toHaveAttribute("aria-valuenow", "50");
+    expect(scrub).toHaveAttribute("aria-valuemin", "0");
+    expect(scrub).toHaveAttribute("aria-valuemax", "100");
+    expect(scrub.getAttribute("aria-valuetext")).not.toBeNull();
+
+    scrub.focus();
+    await userEvent.keyboard("{ArrowRight}");
+    expect(scrub).toHaveAttribute("aria-valuenow", "51");
+  });
+
+  it("diagonal direction follows the dominant axis", () => {
+    const mock = setupPointerLockMock();
+    const onChange = vi.fn();
+
+    render(
+      <NumberField.Root defaultValue={50} step={1} onChange={onChange}>
+        <NumberField.ScrubArea data-testid="scrub-area" direction="both" pixelSensitivity={4}>
+          Drag
+        </NumberField.ScrubArea>
+        <NumberField.Input />
+      </NumberField.Root>
+    );
+
+    const scrubArea = screen.getByTestId("scrub-area");
+    fireEvent.pointerDown(scrubArea, { button: 0, bubbles: true });
+
+    // Dominant +X (|dx| >= |dy|) → uses dx → increment (up from 50).
+    mock.simulateMouseMove(8, 2);
+    expect(onChange).toHaveBeenCalledWith(51);
+
+    onChange.mockClear();
+
+    // Dominant -Y (|dy| > |dx|) → uses -dy → up = increment (up from 50).
+    mock.simulateMouseMove(2, -8);
+    expect(onChange).toHaveBeenCalledWith(51);
+
+    onChange.mockClear();
+
+    // Sanity: dominant +Y (|dy| > |dx|) → uses -dy → down = decrement.
+    mock.simulateMouseMove(2, 8);
+    expect(onChange).toHaveBeenCalledWith(49);
+  });
+
+  it("clears scrubbing state on pointer-lock release", () => {
+    const mock = setupPointerLockMock();
+    const onChange = vi.fn();
+
+    render(
+      <NumberField.Root defaultValue={50} step={1} onChange={onChange}>
+        <NumberField.ScrubArea data-testid="scrub-area" pixelSensitivity={4}>
+          Drag
+        </NumberField.ScrubArea>
+        <NumberField.Input />
+      </NumberField.Root>
+    );
+
+    const scrubArea = screen.getByTestId("scrub-area");
+    fireEvent.pointerDown(scrubArea, { button: 0, bubbles: true });
+    expect(scrubArea).toHaveAttribute("data-scrubbing", "");
+
+    // Release the lock — the mock fires pointerlockchange synchronously.
+    act(() => {
+      document.exitPointerLock();
+    });
+
+    expect(scrubArea).not.toHaveAttribute("data-scrubbing");
+
+    // A subsequent move must no longer change the value.
+    onChange.mockClear();
+    mock.simulateMouseMove(4, 0);
+    expect(onChange).not.toHaveBeenCalled();
   });
 });

--- a/src/react/behavior/i18n.test.tsx
+++ b/src/react/behavior/i18n.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { type, renderField, norm } from "../../test-utils.js";
 // Native-digit locales must register their digit blocks before use.
 import "../../locales/fa.js";
@@ -175,5 +176,53 @@ describe("i18n: switching locale reformats an idle value", () => {
   it("mounting 1234 in de-DE formats with period grouping", () => {
     const de = renderField({ locale: "de-DE", defaultValue: 1234 });
     expect(norm(de.display())).toBe("1.234");
+  });
+});
+
+// ── Runtime locale switch on a CONTROLLED value, focus-aware ──────────────────
+
+describe("i18n: controlled value + runtime locale change", () => {
+  function Controlled({ locale, value }: { locale: string; value: number }) {
+    return (
+      <NumberField.Root locale={locale} value={value}>
+        <NumberField.Input data-testid="ctrl-input" />
+      </NumberField.Root>
+    );
+  }
+
+  it("does NOT reformat the in-progress display when the locale changes while FOCUSED", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<Controlled locale="en-US" value={1234} />);
+    const input = screen.getByTestId("ctrl-input") as HTMLInputElement;
+    // Idle en-US display.
+    expect(norm(input.value)).toBe("1,234");
+
+    // Focus and make a partial, in-progress edit so the display is mid-edit.
+    await user.click(input);
+    input.setSelectionRange(input.value.length, input.value.length);
+    await user.type(input, "5", {
+      initialSelectionStart: input.value.length,
+      initialSelectionEnd: input.value.length,
+    });
+    const midEdit = input.value;
+    // The in-progress edit must carry the new digit (en-US grouping).
+    expect(norm(midEdit)).toBe("12,345");
+
+    // Switch locale WHILE STILL FOCUSED — the `!isFocused` guard must hold, so
+    // the in-progress display is preserved verbatim (no de-DE re-grouping).
+    rerender(<Controlled locale="de-DE" value={1234} />);
+    expect(input.value).toBe(midEdit);
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("reformats a controlled value to the new locale grouping when IDLE", () => {
+    const { rerender } = render(<Controlled locale="en-US" value={1234} />);
+    const input = screen.getByTestId("ctrl-input") as HTMLInputElement;
+    // en-US comma grouping.
+    expect(norm(input.value)).toBe("1,234");
+
+    // Not focused: a locale change reformats the same controlled value.
+    rerender(<Controlled locale="de-DE" value={1234} />);
+    expect(norm(input.value)).toBe("1.234");
   });
 });

--- a/src/react/behavior/paste.test.tsx
+++ b/src/react/behavior/paste.test.tsx
@@ -115,3 +115,53 @@ describe("constraint flags on paste", () => {
     expect(norm(r.committedDisplay)).toBe("15");
   });
 });
+
+// A custom parseValue paired with a NON-invertible custom formatValue is the
+// canonical magnitude-loss trap: the display ("1.2K") can never be re-parsed
+// back to 1234. The paste path threads the parser's known value into state so
+// the committed numeric value stays exact instead of being re-derived from the
+// lossy display.
+describe("custom parseValue / formatValue on paste", () => {
+  it("preserves the parsed magnitude through a non-invertible formatValue", async () => {
+    const r = await paste(
+      {
+        parseValue: (s: string) => {
+          const n = parseFloat(s.replace(/[^0-9.\-]/g, ""));
+          return { value: Number.isNaN(n) ? null : n, isIntermediate: false };
+        },
+        formatValue: (v: number) => `${(v / 1000).toFixed(1)}K`,
+      },
+      "1234"
+    );
+    // Magnitude is the exact parsed value, NOT re-derived from the "1.2K" display.
+    expect(r.committedValue).toBe(1234);
+    expect(norm(r.committedDisplay)).toBe("1.2K");
+  });
+});
+
+// Step 4 of the paste pipeline: when the primary locale parse fails, the
+// digit-only fallback strips everything but digits / locale decimal / sign and
+// re-parses. In fa-IR the decimal separator is U+066B, so ASCII dots are NOT
+// the decimal — "1.2.3" has two stray ASCII dots the primary parse rejects, and
+// the fallback recovers the integer 123.
+describe("locale digit-only fallback on paste", () => {
+  it("fa: strips ASCII dots that are not the locale decimal, recovering 123", async () => {
+    const r = await paste({ locale: "fa" }, "1.2.3");
+    expect(r.committedValue).toBe(123);
+  });
+});
+
+describe("ReDoS guard on paste", () => {
+  it("discards an absurdly long paste without catastrophic backtracking", async () => {
+    // The old ambiguous regexes in parseSpecialNotation backtracked ~O(n^2):
+    // 100k chars took ~10s, which would exceed the test timeout. The length
+    // guard + de-ambiguated patterns keep this instant; the field stays empty.
+    const huge = `${"9".repeat(100000)}k9`;
+    const start = performance.now();
+    const r = await paste({ locale: "en-US" }, huge);
+    const elapsed = performance.now() - start;
+    expect(r.committedValue).toBeNull();
+    expect(r.committedDisplay).toBe("");
+    expect(elapsed).toBeLessThan(2000);
+  });
+});

--- a/src/react/useNumberField.ts
+++ b/src/react/useNumberField.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { computeNewCursorPosition } from "../core/cursor.js";
-import { createFormatter } from "../core/formatter.js";
+import { createFormatter, resolveEffectiveFractions } from "../core/formatter.js";
 import { localizeDigits, normalizeDigits } from "../core/normalizer.js";
 import { createParser } from "../core/parser.js";
 import type { NumberFieldAria, NumberFieldState, UseNumberFieldProps } from "../core/types.js";
@@ -24,12 +24,19 @@ function escapeRegex(s: string): string {
  * Returns null when `s` is not one of these forms.
  */
 function parseSpecialNotation(s: string): number | null {
+  // Bound length before the regexes (this runs on attacker-controllable paste
+  // text). The patterns are also de-ambiguated below so they match in linear
+  // time — together this closes the ReDoS on the paste path.
+  if (s.length > 256) return null;
   const t = s.replace(/\s+/g, "");
-  if (/^[+-]?(?:\d+\.?\d*|\.\d+)[eE][+-]?\d+$/.test(t)) {
+  // Note the de-ambiguated mantissa `\d+(?:\.\d*)?|\.\d+` (no overlapping
+  // `\d+\.?\d*` alternation) — the old form backtracked quadratically on a long
+  // failing input.
+  if (/^[+-]?(?:\d+(?:\.\d*)?|\.\d+)[eE][+-]?\d+$/.test(t)) {
     const n = Number(t);
     return Number.isFinite(n) ? n : null;
   }
-  const m = t.match(/^([+-]?(?:\d+\.?\d*|\.\d+))(k|m|b|t|thousand|million|billion|trillion)$/i);
+  const m = t.match(/^([+-]?(?:\d+(?:\.\d*)?|\.\d+))(k|m|b|t|thousand|million|billion|trillion)$/i);
   if (m) {
     const mult: Record<string, number> = {
       k: 1e3,
@@ -101,10 +108,14 @@ export function useNumberField(
   const errorId = `${inputId}-error`;
 
   // ── Formatter & parser (kept in sync with state's) ──────────────────────
-  // Mirror the state hook: drop fraction padding when decimals are disallowed.
-  const effMinFrac = allowDecimal ? minimumFractionDigits : 0;
-  const effMaxFrac = allowDecimal ? maximumFractionDigits : 0;
-  const effFixedScale = allowDecimal ? fixedDecimalScale : false;
+  // Same effective-fraction resolution as the state hook, via one shared helper,
+  // so the live-typing and on-commit displays can never drift apart.
+  const { effMinFrac, effMaxFrac, effFixedScale } = resolveEffectiveFractions({
+    allowDecimal,
+    minimumFractionDigits,
+    maximumFractionDigits,
+    fixedDecimalScale,
+  });
 
   const formatter = useMemo(
     () =>
@@ -259,8 +270,12 @@ export function useNumberField(
       const normalized = normalizeDigits(composedValue);
 
       let displayValue: string;
+      // Thread the custom parser's value through to state — otherwise the state
+      // hook re-derives it with the BUILT-IN parser, discarding the custom result.
+      let composedKnownValue: number | null | undefined;
       if (customParseValue) {
         const result = customParseValue(normalized);
+        if (result.value !== null) composedKnownValue = result.value;
         if (result.isIntermediate) {
           displayValue = normalized;
         } else if (result.value !== null && customFormatValue) {
@@ -297,7 +312,7 @@ export function useNumberField(
       }
 
       state._setLastChangeReason("input");
-      state.setInputValue(displayValue);
+      state.setInputValue(displayValue, composedKnownValue);
     },
     [formatter, liveFormatter, parser, liveFormat, state, customFormatValue, customParseValue]
   );
@@ -348,6 +363,10 @@ export function useNumberField(
       // Custom parse/format escape hatch
       if (customParseValue) {
         const result = customParseValue(normalized);
+        // Thread the custom parser's value through to state — otherwise the state
+        // hook re-parses the (custom-formatted) display with the BUILT-IN parser
+        // and silently overrides numberValue.
+        if (result.value !== null) knownValue = result.value;
         if (result.isIntermediate) {
           displayValue = normalized;
         } else if (result.value !== null) {
@@ -443,6 +462,10 @@ export function useNumberField(
       e.preventDefault();
       const text = e.clipboardData.getData("text/plain");
       if (!text) return;
+      // Discard absurdly long clipboard payloads up front — no legitimate number
+      // is this long, and it bounds every downstream scan/regex on this
+      // attacker-controllable input.
+      if (text.length > 1000) return;
 
       // 1. Strip common currency symbols (global currencies)
       const stripped = text.replace(/[€$£¥₹₺₽﷼฿₩¢₦₨₪₫₱]/g, "").trim();

--- a/src/react/useNumberField.ts
+++ b/src/react/useNumberField.ts
@@ -275,7 +275,9 @@ export function useNumberField(
       let composedKnownValue: number | null | undefined;
       if (customParseValue) {
         const result = customParseValue(normalized);
-        if (result.value !== null) composedKnownValue = result.value;
+        // Honor an explicit null too (a custom parser rejecting the composed
+        // text), so the built-in parser can't re-derive a value for it.
+        composedKnownValue = result.value;
         if (result.isIntermediate) {
           displayValue = normalized;
         } else if (result.value !== null && customFormatValue) {
@@ -363,10 +365,11 @@ export function useNumberField(
       // Custom parse/format escape hatch
       if (customParseValue) {
         const result = customParseValue(normalized);
-        // Thread the custom parser's value through to state — otherwise the state
-        // hook re-parses the (custom-formatted) display with the BUILT-IN parser
-        // and silently overrides numberValue.
-        if (result.value !== null) knownValue = result.value;
+        // Thread the custom parser's value through to state — including an
+        // explicit null (a custom parser that rejects input). Otherwise the
+        // state hook re-parses the display with the BUILT-IN parser and could
+        // emit a number the custom parser deliberately rejected.
+        knownValue = result.value;
         if (result.isIntermediate) {
           displayValue = normalized;
         } else if (result.value !== null) {

--- a/src/react/useNumberFieldState.ts
+++ b/src/react/useNumberFieldState.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef, useState } from "react";
-import { createFormatter } from "../core/formatter.js";
+import { createFormatter, resolveEffectiveFractions } from "../core/formatter.js";
 import { createParser } from "../core/parser.js";
 import type { ChangeReason, NumberFieldState, UseNumberFieldStateOptions } from "../core/types.js";
 import { useControllableState } from "./useControllableState.js";
@@ -60,12 +60,16 @@ export function useNumberFieldState(options: UseNumberFieldStateOptions): Number
     formatValue: customFormatValue,
   } = options;
 
-  // When decimals are disallowed, force the formatter to 0 fraction digits so
+  // When decimals are disallowed, fraction padding/scale is forced to 0 so
   // currency / fixedDecimalScale never pad ".00" (which the dot-strip would then
-  // re-read, exploding the value). See XF-2.
-  const effMinFrac = allowDecimal ? minimumFractionDigits : 0;
-  const effMaxFrac = allowDecimal ? maximumFractionDigits : 0;
-  const effFixedScale = allowDecimal ? fixedDecimalScale : false;
+  // re-read, exploding the value). Shared with useNumberField via one helper so
+  // the editable and on-commit displays can never drift apart.
+  const { effMinFrac, effMaxFrac, effFixedScale } = resolveEffectiveFractions({
+    allowDecimal,
+    minimumFractionDigits,
+    maximumFractionDigits,
+    fixedDecimalScale,
+  });
 
   // ── Formatter & parser (re-created only when deps change) ──────────────────
   const formatter = useMemo(
@@ -145,6 +149,13 @@ export function useNumberFieldState(options: UseNumberFieldStateOptions): Number
 
   const [inputValue, setInputValueRaw] = useState<string>(initialDisplay);
 
+  // Mirror of the display string, updated SYNCHRONOUSLY before each setNumberValue
+  // (which fires onChange). `inputValue` state only reflects the *previous* render
+  // at onChange time, so consumers reading the formatted value via onValueChange
+  // must read this ref to get the value that matches the just-emitted number.
+  const latestDisplayRef = useRef<string>(initialDisplay);
+  const _getLatestDisplay = useCallback((): string => latestDisplayRef.current, []);
+
   // Track last formatted value so we can sync controlled value changes
   const lastFormattedRef = useRef<string>(initialDisplay);
 
@@ -215,6 +226,7 @@ export function useNumberFieldState(options: UseNumberFieldStateOptions): Number
       const finite = ev != null && Number.isFinite(ev);
       const formatted = finite ? formatDisplay(ev as number) : "";
       lastFormattedRef.current = formatted;
+      latestDisplayRef.current = formatted;
       setInputValueRaw(formatted);
       setRawValueState(finite ? String(ev) : null);
     }
@@ -232,6 +244,7 @@ export function useNumberFieldState(options: UseNumberFieldStateOptions): Number
       if (formatted !== inputValue) {
         setInputValueRaw(formatted);
         lastFormattedRef.current = formatted;
+        latestDisplayRef.current = formatted;
       }
     }
   }
@@ -261,6 +274,7 @@ export function useNumberFieldState(options: UseNumberFieldStateOptions): Number
         if (maxValue !== undefined && value > maxValue) return;
       }
 
+      latestDisplayRef.current = val;
       setInputValueRaw(val);
       lastEmittedRef.current = value;
       setNumberValue(value);
@@ -302,18 +316,20 @@ export function useNumberFieldState(options: UseNumberFieldStateOptions): Number
   // ── setNumberValue (external) ──────────────────────────────────────────────
   const setNumericValue = useCallback(
     (val: number | null) => {
+      // Compute the display and update latestDisplayRef BEFORE setNumberValue, so
+      // the onChange it triggers reports the matching formatted value (not the
+      // previous render's).
+      const formatted = val != null ? formatDisplay(val) : "";
+      latestDisplayRef.current = formatted;
       lastEmittedRef.current = val;
       setNumberValue(val);
+      setInputValueRaw(formatted);
+      lastFormattedRef.current = formatted;
       if (val != null) {
-        const formatted = formatDisplay(val);
-        setInputValueRaw(formatted);
-        lastFormattedRef.current = formatted;
         const rawStr = String(val);
         setRawValueState(rawStr);
         onRawChange?.(rawStr);
       } else {
-        setInputValueRaw("");
-        lastFormattedRef.current = "";
         setRawValueState(null);
         onRawChange?.(null);
       }
@@ -325,6 +341,7 @@ export function useNumberFieldState(options: UseNumberFieldStateOptions): Number
   // ── commit (called on blur) ────────────────────────────────────────────────
   const commit = useCallback((): number | null => {
     if (numberValue == null) {
+      latestDisplayRef.current = "";
       setInputValueRaw("");
       lastFormattedRef.current = "";
       return null;
@@ -339,6 +356,7 @@ export function useNumberFieldState(options: UseNumberFieldStateOptions): Number
     if (Object.is(clamped, -0)) clamped = 0;
 
     const formatted = formatDisplay(clamped);
+    latestDisplayRef.current = formatted;
     setInputValueRaw(formatted);
     lastFormattedRef.current = formatted;
 
@@ -441,6 +459,7 @@ export function useNumberFieldState(options: UseNumberFieldStateOptions): Number
     validationError,
     _setLastChangeReason,
     _getLastChangeReason,
+    _getLatestDisplay,
     setInputValue,
     setNumberValue: setNumericValue,
     commit,

--- a/src/react/usePressAndHold.test.ts
+++ b/src/react/usePressAndHold.test.ts
@@ -151,6 +151,55 @@ describe("usePressAndHold", () => {
     expect(cb).toHaveBeenCalledTimes(2);
   });
 
+  it("stops repeating when disabled mid-hold (no pointerUp)", () => {
+    const cb = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ disabled }: { disabled: boolean }) =>
+        usePressAndHold(cb, { delay: 400, interval: 200, disabled }),
+      { initialProps: { disabled: false } }
+    );
+
+    act(() => {
+      result.current.onPointerDown(makePointerEvent());
+    });
+
+    // immediate fire + first repeat at the 400ms delay → count = 2
+    act(() => { vi.advanceTimersByTime(400); });
+    expect(cb).toHaveBeenCalledTimes(2);
+
+    // Become disabled mid-hold WITHOUT a pointerUp/leave to clear the timer.
+    act(() => {
+      rerender({ disabled: true });
+    });
+
+    const callsAtDisable = cb.mock.calls.length;
+
+    // The runaway loop must have stopped — no further fires no matter how long.
+    act(() => { vi.advanceTimersByTime(5000); });
+    expect(cb).toHaveBeenCalledTimes(callsAtDisable);
+  });
+
+  it("stops repeating on pointerCancel", () => {
+    const cb = vi.fn();
+    const { result } = renderHook(() =>
+      usePressAndHold(cb, { delay: 400, interval: 200 })
+    );
+
+    act(() => {
+      result.current.onPointerDown(makePointerEvent());
+    });
+
+    act(() => { vi.advanceTimersByTime(400); });
+    expect(cb).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      result.current.onPointerCancel(makePointerEvent());
+    });
+
+    act(() => { vi.advanceTimersByTime(2000); });
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+
   it("cancels pending timers on unmount", () => {
     const cb = vi.fn();
     const { result, unmount } = renderHook(() =>

--- a/src/react/usePressAndHold.ts
+++ b/src/react/usePressAndHold.ts
@@ -15,6 +15,8 @@ export interface PressAndHoldProps {
   onPointerDown: (e: React.PointerEvent) => void;
   onPointerUp: (e: React.PointerEvent) => void;
   onPointerLeave: (e: React.PointerEvent) => void;
+  onPointerCancel: (e: React.PointerEvent) => void;
+  onLostPointerCapture: (e: React.PointerEvent) => void;
 }
 
 /**
@@ -48,6 +50,14 @@ export function usePressAndHold(
     intervalRef.current = interval;
   });
 
+  // Track disabled in a ref so an in-flight repeat loop can stop the instant the
+  // control becomes disabled (e.g. the value hits min/max) — a disabled <button>
+  // stops dispatching the pointerup/leave that would normally clear the timer.
+  const disabledRef = useRef(disabled);
+  useEffect(() => {
+    disabledRef.current = disabled;
+  });
+
   // Timer handle refs (null = no active timer)
   const delayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const repeatTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -66,14 +76,20 @@ export function usePressAndHold(
   }, []);
 
   // Recursive accelerating repeat
-  const scheduleRepeat = useCallback((currentInterval: number) => {
-    if (!isHeldRef.current) return;
-    callbackRef.current();
-    const nextInterval = Math.max(50, Math.floor(currentInterval / 2));
-    repeatTimerRef.current = setTimeout(() => {
-      scheduleRepeat(nextInterval);
-    }, currentInterval);
-  }, []);
+  const scheduleRepeat = useCallback(
+    (currentInterval: number) => {
+      if (!isHeldRef.current || disabledRef.current) {
+        clearTimers();
+        return;
+      }
+      callbackRef.current();
+      const nextInterval = Math.max(50, Math.floor(currentInterval / 2));
+      repeatTimerRef.current = setTimeout(() => {
+        scheduleRepeat(nextInterval);
+      }, currentInterval);
+    },
+    [clearTimers]
+  );
 
   const onPointerDown = useCallback(
     (e: React.PointerEvent) => {
@@ -109,8 +125,32 @@ export function usePressAndHold(
     [clearTimers]
   );
 
+  // Touch interruptions (scroll/gesture) and pointer-capture loss must also stop
+  // the repeat — otherwise the timer keeps firing with no release event.
+  const onPointerCancel = useCallback(
+    (e: React.PointerEvent) => {
+      void e;
+      clearTimers();
+    },
+    [clearTimers]
+  );
+
+  const onLostPointerCapture = useCallback(
+    (e: React.PointerEvent) => {
+      void e;
+      clearTimers();
+    },
+    [clearTimers]
+  );
+
+  // Stop an in-flight repeat as soon as the control becomes disabled — a disabled
+  // <button> no longer fires pointerup/leave, so the loop would otherwise run on.
+  useEffect(() => {
+    if (disabled) clearTimers();
+  }, [disabled, clearTimers]);
+
   // Safety: clear on unmount
   useEffect(() => clearTimers, [clearTimers]);
 
-  return { onPointerDown, onPointerUp, onPointerLeave };
+  return { onPointerDown, onPointerUp, onPointerLeave, onPointerCancel, onLostPointerCapture };
 }

--- a/src/react/useScrubArea.ts
+++ b/src/react/useScrubArea.ts
@@ -12,6 +12,11 @@ export interface ScrubAreaReturn {
     tabIndex: number;
     style: React.CSSProperties;
     "aria-label": string;
+    "aria-valuenow": number | undefined;
+    "aria-valuemin": number | undefined;
+    "aria-valuemax": number | undefined;
+    "aria-valuetext": string | undefined;
+    "aria-disabled": true | undefined;
     "data-scrubbing": string | undefined;
     onPointerDown: (e: React.PointerEvent) => void;
     onKeyDown: (e: React.KeyboardEvent) => void;
@@ -171,6 +176,14 @@ export function useScrubArea(
       WebkitUserSelect: "none" as const,
     } satisfies React.CSSProperties,
     "aria-label": label,
+    // role="slider" requires the current value (and ideally the range) to be
+    // exposed, else assistive tech announces a value-less slider with no feedback
+    // when the user scrubs with the arrow keys.
+    "aria-valuenow": state.numberValue ?? undefined,
+    "aria-valuemin": state.options.minValue,
+    "aria-valuemax": state.options.maxValue,
+    "aria-valuetext": state.inputValue || undefined,
+    "aria-disabled": state.options.disabled ? (true as const) : undefined,
     "data-scrubbing": isScrubbing ? "" : undefined,
     onPointerDown,
     onKeyDown,


### PR DESCRIPTION
## Summary

Acts on a **fresh, unbiased multi-agent review** of the whole `src/` (independent reviewers per dimension → adversarial verification of every finding). It surfaced a new set of defects with **no overlap** with #31, and every fix here was itself put through an adversarial verification pass.

> **Stacked on #31.** Base is `fix/a11y-scrub-rawvalue` so this diff shows only round-2 changes. Merge #31 first (or retarget to `main` after #31 lands).

The verification loop earned its keep: it caught that the first pass *claimed* to fix `parseSpecialNotation` but never touched it, leaving the ReDoS live on the paste path. That is now genuinely fixed and tested.

## Security
- **Eliminate quadratic-backtracking ReDoS.** The numeric-validation regexes (core `parse` **and** the scientific/compact `parseSpecialNotation` used on paste) are rewritten without the ambiguous `(?:\d+\.?\d*|\.\d+)` alternation so they match in linear time. Length is bounded up front: `parse()` rejects >256 chars, `parseSpecialNotation` >256, and `handlePaste` discards clipboard text >1000 chars before any scan. A long crafted paste can no longer freeze the main thread.

## Correctness
- **RTL accounting sign flip.** Strip the invisible bidi mark `Intl` prepends before `(` (fa-IR etc.) before the accounting-paren match, so negatives survive the format→parse round-trip instead of silently becoming positive.
- **Scientific notation in the core parser.** `createParser` now parses `"1.234E3" → 1234`, `"1e3" → 1000`, `"1.5e-3" → 0.0015` (negative exponents preserved) instead of dropping the exponent and producing a corrupt value; malformed exponents are rejected, and a fractional exponent value is rejected under `allowDecimal:false` for parity with the plain-decimal path.
- **`onValueChange` reports the correct `formattedValue`.** It was one update stale (typing `5` reported `""`); now read from a synchronously-updated display mirror across the typing / step / scrub / commit / controlled-sync paths.
- **Custom `parseValue` honored while typing & via IME.** Its result is threaded to `numberValue` instead of being re-derived (and discarded) by the built-in parser.
- **Steppers can't run away.** Press-and-hold stops the moment the button disables mid-hold (value hits min/max), and on `onPointerCancel` / `onLostPointerCapture`.
- **Fullwidth CJK digits** (U+FF10–U+FF19, full-width IMEs) are normalized so that input parses.

## Accessibility
- `<NumberField.ScrubArea>` (`role="slider"`) now exposes `aria-valuenow` / `aria-valuemin` / `aria-valuemax` / `aria-valuetext` and `aria-disabled`.

## Maintainability / docs
- Extract `resolveEffectiveFractions`, shared by both hooks (removes hand-mirrored fraction-digit logic).
- Docs updated: scrub slider ARIA, press-hold cancel handlers, fullwidth now built-in.

## Tests
- **+29 regression tests** covering every fix, including a paste-ReDoS guard (a quadratic regex would exceed the test timeout), RTL accounting round-trip, scientific parsing, stale-`formattedValue`, custom-`parseValue` typing, disabled-mid-hold steppers, scrub slider ARIA, fullwidth digits, and controlled+locale-change. **660 tests pass; typecheck, lint, build green.**

## Not addressed (deliberate)
- Context/memo re-render perf (LOW): the verification disproved the measurable impact (no cross-field amplification), and a real fix needs a context-split refactor disproportionate to the gain. Deferred with rationale rather than shipping no-op memoization.

## Changeset
Included (`minor` — additive public API: scrub value ARIA, press-hold handlers, scientific parsing; plus behavior fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
