### PR TITLE
perf: strip dev warnings in production and trim per-render work

### DIFF
--- a/.changeset/optimize-size-and-render-cost.md
+++ b/.changeset/optimize-size-and-render-cost.md
@@ -1,0 +1,12 @@
+---
+"raqam": patch
+---
+
+perf: shrink the bundle and trim per-render work (no API changes)
+
+- **Smaller production bundle.** The dev-only warnings (invalid `formatOptions`, controlled/uncontrolled switch, missing `<NumberField.Root>`) are now wrapped in `process.env.NODE_ENV !== "production"` guards that production bundlers statically dead-code-eliminate, so they ship **zero bytes in production** while still surfacing in development. `dist` keeps the guards, so a consumer's dev build still shows them. Min+brotli: core 2.37 → 2.23 kB, react 9.69 → 9.42 kB, full 9.84 → 9.62 kB.
+- **Cheaper renders.** `JSON.stringify(formatOptions)` is now computed once per render instead of in every `useMemo` dependency array (was up to 7 calls/render across the state and behavior hooks).
+- **Cheaper keystrokes.** Removed a redundant digit-normalization pass in the cursor engine (the sole caller already normalizes).
+- **Internal cleanups.** Deduplicated the label/description mount-tracking into one hook; hoisted a constant out of the paste hot path.
+
+Note: under raw-browser ESM (no bundler), all dev diagnostics are now gated off and the missing-`<NumberField.Root>` error degrades to a short message. Bundler users get the full warnings in development as before.

--- a/.changeset/site-url-and-size-docs.md
+++ b/.changeset/site-url-and-size-docs.md
@@ -1,0 +1,8 @@
+---
+"raqam": patch
+---
+
+docs: move the site to the custom domain `raqam.47vigen.com` and refresh bundle-size figures
+
+- Repointed the package `homepage`, the docs canonical `siteUrl`, and every documentation link from `raqam.vercel.app` to `raqam.47vigen.com`.
+- Updated the README bundle-size table and comparison row to the current measured sizes (core ~2.23 KB, react ~9.42 KB, full ~9.62 KB, min+brotli) and corrected the stale "under 2 KB gzipped" contributor guideline to reference the `.size-limit.json` budgets.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ For the **design rationale** behind this architecture — why input is always
 `type="text"`, how the cursor-preservation algorithm works, the i18n/RTL
 strategy, and the full set of ADRs — see [`DEFINITION.md`](DEFINITION.md) (the
 original design spec). For the user-facing API, see [`README.md`](README.md) and
-the [docs site](https://raqam.vercel.app).
+the [docs site](https://raqam.47vigen.com).
 
 ## Testing
 
@@ -122,6 +122,6 @@ npx changeset
 
 - **TypeScript strict mode**: All code must pass `tsc --noEmit` with zero errors
 - **No new dependencies**: The core must remain zero-dep; React is a peer dep only
-- **Bundle size**: Check `pnpm size` — the core must stay under 2 KB gzipped
+- **Bundle size**: Check `pnpm size` — every entry must stay within its [`.size-limit.json`](.size-limit.json) budget (e.g. `raqam/core` ≤ 2.5 KB min+brotli)
 - **Accessibility**: All interactive components must have correct ARIA attributes
 - **i18n**: Never hardcode locale-specific strings — always use `Intl.NumberFormat`

--- a/DEFINITION.md
+++ b/DEFINITION.md
@@ -9,7 +9,7 @@
 >
 > For the **shipped API and current usage**, see:
 > - [`README.md`](README.md) — quick start + API tables
-> - The docs site — <https://raqam.vercel.app>
+> - The docs site — <https://raqam.47vigen.com>
 > - [`CHANGELOG.md`](CHANGELOG.md) — what actually shipped per release
 >
 > The architecture rationale below (ADRs §4, the cursor engine §6, the i18n/RTL

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | Truly headless | ✅ | ✅ | ❌ | ✅ |
 | i18n digit input (Persian ۱۲۳, Arabic ١٢٣…) | ❌ | ✅ | ❌ | ✅ |
 | WAI-ARIA spinbutton | ✅ | ✅✅ | ⚠️ | ✅✅ |
-| Bundle size | ~10 KB | ~30 KB | ~60 KB | **~2.4 KB core** |
+| Bundle size | ~10 KB | ~30 KB | ~60 KB | **~2.2 KB core** |
 
 No existing package combines all four. raqam does.
 
@@ -303,7 +303,7 @@ State management hook — returns `NumberFieldState`.
 | `required` | `boolean` | `false` | Mark the field as required |
 
 Also accepts `maximumFractionDigits`, `minimumFractionDigits`, `formatValue`,
-and `parseValue` — see the [full options reference](https://raqam.vercel.app/docs/api/use-number-field-state).
+and `parseValue` — see the [full options reference](https://raqam.47vigen.com/docs/api/use-number-field-state).
 
 ### `useNumberField(props, state, inputRef)`
 
@@ -318,7 +318,7 @@ every `useNumberFieldState` option plus the behavior-only props below:
 | `stepHoldInterval` | `number` | `200` | Press-and-hold repeat interval (ms) |
 | `label` / `name` / `id` / `aria-*` | `string` | — | Labelling, form name, and id wiring |
 
-→ Full reference: [`useNumberField`](https://raqam.vercel.app/docs/api/use-number-field).
+→ Full reference: [`useNumberField`](https://raqam.47vigen.com/docs/api/use-number-field).
 
 ### `NumberField.Root` extra props
 
@@ -368,9 +368,9 @@ Measured min + brotli (including dependencies), enforced in CI via
 
 | Entry | Size | CI budget |
 |-------|------|-----------|
-| `raqam/core` | ~2.37 KB | 2.5 KB |
-| `raqam` (hooks + components) | ~9.84 KB | 12 KB |
-| `raqam/react` | ~9.69 KB | 10 KB |
+| `raqam/core` | ~2.23 KB | 2.5 KB |
+| `raqam` (hooks + components) | ~9.62 KB | 12 KB |
+| `raqam/react` | ~9.42 KB | 10 KB |
 | `raqam/locales/fa` | 196 B | 0.3 KB |
 
 ## 📄 License

--- a/docs/lib/shared.ts
+++ b/docs/lib/shared.ts
@@ -2,8 +2,9 @@ export const appName = "Raqam";
 export const appDescription =
   "The definitive React number input: live formatting, full i18n, headless, accessible.";
 
-// Canonical site URL (Vercel). Swap for a custom domain when one is attached.
-export const siteUrl = "https://raqam.vercel.app";
+// Canonical site URL (custom domain). No trailing slash — it is concatenated
+// with paths (e.g. `${siteUrl}/sitemap.xml`) and used as a `new URL(...)` base.
+export const siteUrl = "https://raqam.47vigen.com";
 export const docsRoute = "/docs";
 
 export const gitConfig = {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "types": "./dist/index.d.ts",
   "author": "47vigen",
   "license": "MIT",
-  "homepage": "https://raqam.vercel.app",
+  "homepage": "https://raqam.47vigen.com/",
   "repository": {
     "type": "git",
     "url": "https://github.com/47vigen/raqam"

--- a/skills/raqam/SKILL.md
+++ b/skills/raqam/SKILL.md
@@ -7,7 +7,7 @@ description: Teaches the raqam React number-input library — headless NumberFie
 
 ## Canonical sources (read these for full detail)
 
-- **Docs site:** [https://raqam.vercel.app](https://raqam.vercel.app)
+- **Docs site:** [https://raqam.47vigen.com](https://raqam.47vigen.com)
 - **README (quick API tables):** [https://github.com/47vigen/raqam/blob/main/README.md](https://github.com/47vigen/raqam/blob/main/README.md)
 - **Package:** [https://www.npmjs.com/package/raqam](https://www.npmjs.com/package/raqam)
 - **Issues:** [https://github.com/47vigen/raqam/issues](https://github.com/47vigen/raqam/issues)
@@ -41,24 +41,24 @@ npm install raqam
 | `raqam/locales/<lang>` | Side-effect plugins: `fa`, `ar`, `bn`, `hi`, `th` (tree-shakeable) |
 | `raqam/locales` | Registers all built-in locale plugins |
 
-Bundle sizes and export map: see README and [Getting Started](https://raqam.vercel.app/docs/getting-started).
+Bundle sizes and export map: see README and [Getting Started](https://raqam.47vigen.com/docs/getting-started).
 
 ## Choose an API
 
 **Compound components (default)** — less boilerplate, context-wired parts:
 
-- Guide: [NumberField components](https://raqam.vercel.app/docs/api/components)
+- Guide: [NumberField components](https://raqam.47vigen.com/docs/api/components)
 - `NumberField.Root` + `Label`, `Group`, `Input`, `Increment`/`Decrement`, `Description`, `ErrorMessage`, `HiddenInput`, `ScrubArea`, `Formatted`, etc.
 
 **Hook API** — full control over DOM and styling:
 
-- [useNumberFieldState](https://raqam.vercel.app/docs/api/use-number-field-state) — state machine (`inputValue`, `numberValue`, `rawValue`, validation, scrubbing).
-- [useNumberField](https://raqam.vercel.app/docs/api/use-number-field) — ARIA props + handlers; requires `inputRef` to the `<input>`.
+- [useNumberFieldState](https://raqam.47vigen.com/docs/api/use-number-field-state) — state machine (`inputValue`, `numberValue`, `rawValue`, validation, scrubbing).
+- [useNumberField](https://raqam.47vigen.com/docs/api/use-number-field) — ARIA props + handlers; requires `inputRef` to the `<input>`.
 
 **Lower-level helpers** — only when building custom primitives or non-React formatting:
 
-- [Core utilities](https://raqam.vercel.app/docs/api/core-utilities) — `createFormatter`, `createParser`, `normalizeDigits`, `registerLocale`, caret helpers.
-- [Advanced primitives](https://raqam.vercel.app/docs/api/advanced-primitives) — `useControllableState`, `usePressAndHold`, `useScrubArea`, `NumberFieldContext`, `useNumberFieldContext`.
+- [Core utilities](https://raqam.47vigen.com/docs/api/core-utilities) — `createFormatter`, `createParser`, `normalizeDigits`, `registerLocale`, caret helpers.
+- [Advanced primitives](https://raqam.47vigen.com/docs/api/advanced-primitives) — `useControllableState`, `usePressAndHold`, `useScrubArea`, `NumberFieldContext`, `useNumberFieldContext`.
 
 ## Recommended agent path
 
@@ -78,52 +78,52 @@ Avoid steering users toward undocumented or stale APIs when a documented path al
 ## Behavior essentials
 
 - **`locale`:** BCP 47 tag; drives `Intl.NumberFormat` / parsing.
-- **`formatOptions`:** standard `Intl.NumberFormatOptions`; use **`presets`** for common cases — [Format presets](https://raqam.vercel.app/docs/api/presets).
-- **Controlled vs uncontrolled:** `value`/`onChange` vs `defaultValue`. `onChange` fires whenever the parsed numeric value changes; use `onValueChange` when you need `{ reason, formattedValue }` metadata, or **`onValueCommitted`** when you only want the settled value (fires on blur → `reason:"blur"`, or Enter → `reason:"keyboard"`). See [Getting Started](https://raqam.vercel.app/docs/getting-started).
+- **`formatOptions`:** standard `Intl.NumberFormatOptions`; use **`presets`** for common cases — [Format presets](https://raqam.47vigen.com/docs/api/presets).
+- **Controlled vs uncontrolled:** `value`/`onChange` vs `defaultValue`. `onChange` fires whenever the parsed numeric value changes; use `onValueChange` when you need `{ reason, formattedValue }` metadata, or **`onValueCommitted`** when you only want the settled value (fires on blur → `reason:"blur"`, or Enter → `reason:"keyboard"`). See [Getting Started](https://raqam.47vigen.com/docs/getting-started).
 - **Change reasons** (`onValueChange` details.reason): `"input"`, `"clear"` (edit empties the field), `"paste"`, `"keyboard"`, `"increment"`, `"decrement"`, `"wheel"`, `"scrub"`, `"blur"`.
 - **Constraints:** `minValue`, `maxValue`, `step`, `largeStep` (default `step×10`), `smallStep` (default `step×0.1`), `clampBehavior` (`"blur"` clamp on blur / `"strict"` reject out-of-range keystrokes / `"none"`), `allowOutOfRange` (keep + commit out-of-range, set `aria-invalid`), `allowNegative`, `allowDecimal`, `fixedDecimalScale` (needs `maximumFractionDigits`).
-- **Live formatting:** formats on every keystroke with a cursor-safe algorithm; **intermediate** values (`1.`, `12.50`, `-`, `.5`) are kept as typed and only normalized on blur. **`compact`/`scientific`/`engineering` notation format on blur** (not live). Percent fields store the *fraction* (`42%` ⇒ `0.42`). Full details: [Formatting & Behavior](https://raqam.vercel.app/docs/guides/formatting).
+- **Live formatting:** formats on every keystroke with a cursor-safe algorithm; **intermediate** values (`1.`, `12.50`, `-`, `.5`) are kept as typed and only normalized on blur. **`compact`/`scientific`/`engineering` notation format on blur** (not live). Percent fields store the *fraction* (`42%` ⇒ `0.42`). Full details: [Formatting & Behavior](https://raqam.47vigen.com/docs/guides/formatting).
 - **Paste:** strips currency symbols, parses scientific/compact (`1e3`, `1.5K`) and accounting parens `(1,234)` ⇒ negative; unparseable pastes are discarded.
 - **Clipboard:** `copyBehavior` `"formatted"` (default) / `"raw"` / `"number"`.
 - **Wheel:** opt-in `allowMouseWheel`; only nudges while the input is focused.
 - **Validation:** `validate` returning `true` / error string; pairs with `NumberField.ErrorMessage`.
 - **Precision / finance:** `onRawChange` and `state.rawValue` give the unformatted, precision-preserving numeric string (affordances stripped, typed trailing zeros kept; falls back to the canonical numeric string for percent/compact/scientific/unit/custom `formatValue`); optional custom `formatValue` / `parseValue`.
-- **Display-only:** [useNumberFieldFormat](https://raqam.vercel.app/docs/api/use-number-field-format) on the client; **`createFormatter` from `raqam/server`** on the server.
+- **Display-only:** [useNumberFieldFormat](https://raqam.47vigen.com/docs/api/use-number-field-format) on the client; **`createFormatter` from `raqam/server`** on the server.
 - **Forms:** for native form submission, put `name` on `NumberField.Root` and render `NumberField.HiddenInput`.
 - **Hook API gotcha:** when using `useNumberFieldState` + `useNumberField` directly, pass the **same formatting options to both** (the behavior hook builds its own formatter/parser). The `NumberField.*` components do this for you.
 
 ## Locales and RTL
 
-- [Locales & i18n](https://raqam.vercel.app/docs/guides/locales) — switching locales, plugins table, `registerLocale` escape hatch.
-- [RTL support](https://raqam.vercel.app/docs/guides/rtl) — RTL layout and behavior.
+- [Locales & i18n](https://raqam.47vigen.com/docs/guides/locales) — switching locales, plugins table, `registerLocale` escape hatch.
+- [RTL support](https://raqam.47vigen.com/docs/guides/rtl) — RTL layout and behavior.
 
 ## Next.js
 
-- [Next.js App Router](https://raqam.vercel.app/docs/guides/nextjs) — `"use client"` for inputs; `raqam/server` for Server Components and edge-safe formatting.
+- [Next.js App Router](https://raqam.47vigen.com/docs/guides/nextjs) — `"use client"` for inputs; `raqam/server` for Server Components and edge-safe formatting.
 
 ## Forms and UI stacks
 
-- [react-hook-form](https://raqam.vercel.app/docs/recipes/react-hook-form)
-- [Formik](https://raqam.vercel.app/docs/recipes/formik)
-- [Tailwind CSS](https://raqam.vercel.app/docs/recipes/tailwind)
-- [shadcn/ui](https://raqam.vercel.app/docs/recipes/shadcn-ui)
-- [Financial app patterns](https://raqam.vercel.app/docs/recipes/financial)
-- [Persian e-commerce](https://raqam.vercel.app/docs/recipes/persian-ecommerce)
+- [react-hook-form](https://raqam.47vigen.com/docs/recipes/react-hook-form)
+- [Formik](https://raqam.47vigen.com/docs/recipes/formik)
+- [Tailwind CSS](https://raqam.47vigen.com/docs/recipes/tailwind)
+- [shadcn/ui](https://raqam.47vigen.com/docs/recipes/shadcn-ui)
+- [Financial app patterns](https://raqam.47vigen.com/docs/recipes/financial)
+- [Persian e-commerce](https://raqam.47vigen.com/docs/recipes/persian-ecommerce)
 
 ## Styling and UX
 
 - Root **`data-*` attributes** for CSS include `data-focused`, `data-invalid`, `data-disabled`, `data-readonly`, `data-required`, and `data-scrubbing`.
 - The input also exposes **`data-rtl`** for RTL-specific styling.
-- **ScrubArea:** pointer-lock drag to change value — [components doc](https://raqam.vercel.app/docs/api/components).
+- **ScrubArea:** pointer-lock drag to change value — [components doc](https://raqam.47vigen.com/docs/api/components).
 - **`render` prop** on compound parts to swap elements without `asChild`.
 
 ## Accessibility
 
-- [Accessibility guide](https://raqam.vercel.app/docs/guides/accessibility) — `spinbutton`, keyboard table, focus model (Tab targets input; steppers use arrow keys).
+- [Accessibility guide](https://raqam.47vigen.com/docs/guides/accessibility) — `spinbutton`, keyboard table, focus model (Tab targets input; steppers use arrow keys).
 
 ## Interactive exploration
 
-- [Playground](https://raqam.vercel.app/docs/playground)
+- [Playground](https://raqam.47vigen.com/docs/playground)
 
 ## When the model needs more detail
 
@@ -136,19 +136,19 @@ Avoid steering users toward undocumented or stale APIs when a documented path al
 
 | Topic | URL |
 |--------|-----|
-| Getting Started | [https://raqam.vercel.app/docs/getting-started](https://raqam.vercel.app/docs/getting-started) |
-| Playground | [https://raqam.vercel.app/docs/playground](https://raqam.vercel.app/docs/playground) |
-| useNumberFieldState | [https://raqam.vercel.app/docs/api/use-number-field-state](https://raqam.vercel.app/docs/api/use-number-field-state) |
-| useNumberField | [https://raqam.vercel.app/docs/api/use-number-field](https://raqam.vercel.app/docs/api/use-number-field) |
-| NumberField components | [https://raqam.vercel.app/docs/api/components](https://raqam.vercel.app/docs/api/components) |
-| Formatting & Behavior | [https://raqam.vercel.app/docs/guides/formatting](https://raqam.vercel.app/docs/guides/formatting) |
-| useNumberFieldFormat | [https://raqam.vercel.app/docs/api/use-number-field-format](https://raqam.vercel.app/docs/api/use-number-field-format) |
-| Format presets | [https://raqam.vercel.app/docs/api/presets](https://raqam.vercel.app/docs/api/presets) |
-| Core utilities | [https://raqam.vercel.app/docs/api/core-utilities](https://raqam.vercel.app/docs/api/core-utilities) |
-| Advanced primitives | [https://raqam.vercel.app/docs/api/advanced-primitives](https://raqam.vercel.app/docs/api/advanced-primitives) |
-| Locales & i18n | [https://raqam.vercel.app/docs/guides/locales](https://raqam.vercel.app/docs/guides/locales) |
-| RTL | [https://raqam.vercel.app/docs/guides/rtl](https://raqam.vercel.app/docs/guides/rtl) |
-| Next.js | [https://raqam.vercel.app/docs/guides/nextjs](https://raqam.vercel.app/docs/guides/nextjs) |
-| Accessibility | [https://raqam.vercel.app/docs/guides/accessibility](https://raqam.vercel.app/docs/guides/accessibility) |
+| Getting Started | [https://raqam.47vigen.com/docs/getting-started](https://raqam.47vigen.com/docs/getting-started) |
+| Playground | [https://raqam.47vigen.com/docs/playground](https://raqam.47vigen.com/docs/playground) |
+| useNumberFieldState | [https://raqam.47vigen.com/docs/api/use-number-field-state](https://raqam.47vigen.com/docs/api/use-number-field-state) |
+| useNumberField | [https://raqam.47vigen.com/docs/api/use-number-field](https://raqam.47vigen.com/docs/api/use-number-field) |
+| NumberField components | [https://raqam.47vigen.com/docs/api/components](https://raqam.47vigen.com/docs/api/components) |
+| Formatting & Behavior | [https://raqam.47vigen.com/docs/guides/formatting](https://raqam.47vigen.com/docs/guides/formatting) |
+| useNumberFieldFormat | [https://raqam.47vigen.com/docs/api/use-number-field-format](https://raqam.47vigen.com/docs/api/use-number-field-format) |
+| Format presets | [https://raqam.47vigen.com/docs/api/presets](https://raqam.47vigen.com/docs/api/presets) |
+| Core utilities | [https://raqam.47vigen.com/docs/api/core-utilities](https://raqam.47vigen.com/docs/api/core-utilities) |
+| Advanced primitives | [https://raqam.47vigen.com/docs/api/advanced-primitives](https://raqam.47vigen.com/docs/api/advanced-primitives) |
+| Locales & i18n | [https://raqam.47vigen.com/docs/guides/locales](https://raqam.47vigen.com/docs/guides/locales) |
+| RTL | [https://raqam.47vigen.com/docs/guides/rtl](https://raqam.47vigen.com/docs/guides/rtl) |
+| Next.js | [https://raqam.47vigen.com/docs/guides/nextjs](https://raqam.47vigen.com/docs/guides/nextjs) |
+| Accessibility | [https://raqam.47vigen.com/docs/guides/accessibility](https://raqam.47vigen.com/docs/guides/accessibility) |
 
-Recipes are linked from the [docs homepage](https://raqam.vercel.app) sidebar.
+Recipes are linked from the [docs homepage](https://raqam.47vigen.com) sidebar.

--- a/skills/raqam/examples.md
+++ b/skills/raqam/examples.md
@@ -1,6 +1,6 @@
 # raqam — patterns and examples
 
-Prefer the **live playground** for experimentation: [https://raqam.vercel.app/docs/playground](https://raqam.vercel.app/docs/playground)
+Prefer the **live playground** for experimentation: [https://raqam.47vigen.com/docs/playground](https://raqam.47vigen.com/docs/playground)
 
 ## Minimal NumberField
 
@@ -56,7 +56,7 @@ import { presets, NumberField } from "raqam";
 </NumberField.Root>
 ```
 
-More preset names and options: [Format presets](https://raqam.vercel.app/docs/api/presets).
+More preset names and options: [Format presets](https://raqam.47vigen.com/docs/api/presets).
 
 ## Persian locale plugin + suffix
 
@@ -201,7 +201,7 @@ The scrub area uses the Pointer Lock API and is keyboard accessible
 
 ## react-hook-form (Controller)
 
-Full recipe: [https://raqam.vercel.app/docs/recipes/react-hook-form](https://raqam.vercel.app/docs/recipes/react-hook-form)
+Full recipe: [https://raqam.47vigen.com/docs/recipes/react-hook-form](https://raqam.47vigen.com/docs/recipes/react-hook-form)
 
 Sketch:
 
@@ -231,12 +231,12 @@ Sketch:
 Style the root with `data-focused`, `data-invalid`, `data-disabled`,
 `data-readonly`, `data-required`, and `data-scrubbing`. For RTL-specific input
 styling, target `input[data-rtl]`. See README and
-[components](https://raqam.vercel.app/docs/api/components).
+[components](https://raqam.47vigen.com/docs/api/components).
 
 ## More recipes (external)
 
-- [Formik](https://raqam.vercel.app/docs/recipes/formik)
-- [Tailwind CSS](https://raqam.vercel.app/docs/recipes/tailwind)
-- [shadcn/ui](https://raqam.vercel.app/docs/recipes/shadcn-ui)
-- [Financial](https://raqam.vercel.app/docs/recipes/financial)
-- [Persian e-commerce](https://raqam.vercel.app/docs/recipes/persian-ecommerce)
+- [Formik](https://raqam.47vigen.com/docs/recipes/formik)
+- [Tailwind CSS](https://raqam.47vigen.com/docs/recipes/tailwind)
+- [shadcn/ui](https://raqam.47vigen.com/docs/recipes/shadcn-ui)
+- [Financial](https://raqam.47vigen.com/docs/recipes/financial)
+- [Persian e-commerce](https://raqam.47vigen.com/docs/recipes/persian-ecommerce)

--- a/src/core/cursor.ts
+++ b/src/core/cursor.ts
@@ -21,14 +21,14 @@ function isAccepted(ch: string, info: LocaleInfo): boolean {
 }
 
 /**
- * Count how many "accepted" characters appear before position `cursor`
- * in `str` (after normalising non-Latin digits to ASCII).
+ * Count how many "accepted" characters appear before position `cursor` in `str`.
+ * `str` must already be digit-normalised (ASCII); the sole caller normalises once
+ * and shares the result, so re-normalising here would just repeat that scan.
  */
 function countAcceptedBefore(str: string, cursor: number, info: LocaleInfo): number {
-  const normalised = normalizeDigits(str);
   let count = 0;
-  for (let i = 0; i < cursor && i < normalised.length; i++) {
-    if (isAccepted(normalised[i]!, info)) count++;
+  for (let i = 0; i < cursor && i < str.length; i++) {
+    if (isAccepted(str[i]!, info)) count++;
   }
   return count;
 }

--- a/src/core/formatter.ts
+++ b/src/core/formatter.ts
@@ -4,20 +4,24 @@ import type { FormatResult, LocaleInfo } from "./types.js";
 
 // Locally declared so the dev-only gate type-checks without @types/node.
 declare const process: { env?: Record<string, string | undefined> } | undefined;
-const IS_PRODUCTION =
-  typeof process !== "undefined" &&
-  typeof process.env !== "undefined" &&
-  process.env.NODE_ENV === "production";
 
 let warnedInvalidOptions = false;
-/** Warn once (dev only) when invalid formatOptions/locale force a fallback. */
+/**
+ * Warn once (dev only) when invalid formatOptions/locale force a fallback. The
+ * `process.env.NODE_ENV !== "production"` token is statically replaced and the
+ * branch dead-code-eliminated by production bundlers that define NODE_ENV
+ * (webpack, Vite, Next, esbuild --minify/--define) — and by raqam's own minified
+ * build — so this message ships zero bytes in production while still surfacing in
+ * development. The `typeof process` / `process.env` guards keep it crash-safe
+ * under raw-browser ESM (no `process`) and partial `process` shims (no `env`);
+ * both sit on the eliminated side of the token, so they cost nothing in prod.
+ */
 function warnInvalidFormatOptions(err: unknown): void {
-  if (IS_PRODUCTION || warnedInvalidOptions) return;
-  warnedInvalidOptions = true;
-  const detail = err instanceof Error ? err.message : String(err);
-  console.warn(
-    `[raqam] Invalid formatOptions/locale — falling back to a safe formatter. Check your \`locale\` and \`formatOptions\` (e.g. style:'currency' requires a \`currency\` code). Original error: ${detail}`
-  );
+  if (typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production") {
+    if (warnedInvalidOptions) return;
+    warnedInvalidOptions = true;
+    console.warn("[raqam] Invalid formatOptions/locale — using a safe fallback.", err);
+  }
 }
 
 /** Probe value that will surface decimal AND grouping parts */

--- a/src/react/context.ts
+++ b/src/react/context.ts
@@ -2,6 +2,9 @@ import { createContext, useContext } from "react";
 import type { RefObject } from "react";
 import type { NumberFieldAria, NumberFieldState, UseNumberFieldProps } from "../core/types.js";
 
+// Locally declared so the dev-only gate type-checks without @types/node.
+declare const process: { env?: Record<string, string | undefined> } | undefined;
+
 export interface NumberFieldContextValue {
   state: NumberFieldState;
   aria: NumberFieldAria;
@@ -18,7 +21,14 @@ export const NumberFieldContext = createContext<NumberFieldContextValue | null>(
 export function useNumberFieldContext(): NumberFieldContextValue {
   const ctx = useContext(NumberFieldContext);
   if (!ctx) {
-    throw new Error("[raqam] NumberField sub-components must be used inside <NumberField.Root>.");
+    // Full guidance in dev; production bundlers strip the guarded branch and ship
+    // only the short identifiable message below. The `typeof process` /
+    // `process.env` guards keep it crash-safe under raw-browser ESM and partial
+    // `process` shims; both sit on the eliminated side of the NODE_ENV token.
+    if (typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production") {
+      throw new Error("[raqam] NumberField sub-components must be used inside <NumberField.Root>.");
+    }
+    throw new Error("[raqam] <NumberField.Root> missing");
   }
   return ctx;
 }

--- a/src/react/useControllableState.ts
+++ b/src/react/useControllableState.ts
@@ -3,15 +3,6 @@ import { useCallback, useRef, useState } from "react";
 // Locally declared so the dev-only gate type-checks without @types/node.
 declare const process: { env?: Record<string, string | undefined> } | undefined;
 
-// Bundlers statically replace `process.env.NODE_ENV`, so the controlled/
-// uncontrolled warning below is dropped from production builds. Falls back to
-// "not production" when `process` is absent (raw-browser ESM), where surfacing a
-// dev-style warning is acceptable.
-const IS_PRODUCTION =
-  typeof process !== "undefined" &&
-  typeof process.env !== "undefined" &&
-  process.env.NODE_ENV === "production";
-
 interface UseControllableStateOptions<T> {
   value?: T;
   defaultValue?: T;
@@ -51,12 +42,19 @@ export function useControllableState<T>({
   const isControlled = value !== undefined;
   const wasControlled = useRef(isControlled);
 
-  if (!IS_PRODUCTION && wasControlled.current !== isControlled) {
-    console.warn(
-      `[raqam] Component is changing from ${
-        wasControlled.current ? "controlled" : "uncontrolled"
-      } to ${isControlled ? "controlled" : "uncontrolled"}. Decide between using a controlled or uncontrolled component and don't switch.`
-    );
+  // Dev-only warning. The `process.env.NODE_ENV !== "production"` token is
+  // statically replaced and the branch eliminated by production bundlers that
+  // define NODE_ENV (and by raqam's minified build), so this ships zero bytes in
+  // production. The `typeof process` / `process.env` guards keep it crash-safe
+  // under raw-browser ESM and partial `process` shims — this runs on every
+  // render, so a throw here would break rendering, not just an error path.
+  if (
+    typeof process !== "undefined" &&
+    process.env &&
+    process.env.NODE_ENV !== "production" &&
+    wasControlled.current !== isControlled
+  ) {
+    console.warn("[raqam] Switching between controlled and uncontrolled. Pick one and keep it.");
   }
 
   const [internalValue, setInternalValue] = useState<T | undefined>(defaultValue);

--- a/src/react/useNumberField.ts
+++ b/src/react/useNumberField.ts
@@ -18,6 +18,29 @@ function escapeRegex(s: string): string {
 }
 
 /**
+ * Track whether at least one element registered through the returned ref
+ * callback is currently mounted. Lets `aria-labelledby` / `aria-describedby`
+ * point at the label / description only while one truly exists — for any render
+ * path (built-in component, custom primitive, or headless) — instead of
+ * dangling at an element that isn't rendered. Ref-counted so multiple mounts and
+ * StrictMode's double-invoke settle to the correct flag.
+ */
+function useMountedFlag(): [boolean, React.RefCallback<HTMLElement>] {
+  const countRef = useRef(0);
+  const [mounted, setMounted] = useState(false);
+  const ref = useCallback<React.RefCallback<HTMLElement>>((node) => {
+    if (node) {
+      countRef.current += 1;
+      setMounted(true);
+    } else if (countRef.current > 0) {
+      countRef.current -= 1;
+      if (countRef.current === 0) setMounted(false);
+    }
+  }, []);
+  return [mounted, ref];
+}
+
+/**
  * The focused element resolved through the node's *root* — `document` in the
  * light DOM, or the containing `ShadowRoot` when the field is inside a shadow
  * tree (where `document.activeElement` only reports the host). Falls back to
@@ -28,6 +51,19 @@ function activeElementWithin(node: Element | null): Element | null {
   if (root && "activeElement" in root) return root.activeElement;
   return typeof document !== "undefined" ? document.activeElement : null;
 }
+
+// Magnitude suffixes for compact-notation paste ("1.5K", "3.4M"). Module-scoped
+// so it isn't rebuilt on every paste.
+const MAGNITUDE_MULTIPLIERS: Record<string, number> = {
+  k: 1e3,
+  thousand: 1e3,
+  m: 1e6,
+  million: 1e6,
+  b: 1e9,
+  billion: 1e9,
+  t: 1e12,
+  trillion: 1e12,
+};
 
 /**
  * Parse scientific ("1e3", "1.23E4") and compact ("1.5K", "3.4M") notation that
@@ -50,17 +86,7 @@ function parseSpecialNotation(s: string): number | null {
   }
   const m = t.match(/^([+-]?(?:\d+(?:\.\d*)?|\.\d+))(k|m|b|t|thousand|million|billion|trillion)$/i);
   if (m) {
-    const mult: Record<string, number> = {
-      k: 1e3,
-      thousand: 1e3,
-      m: 1e6,
-      million: 1e6,
-      b: 1e9,
-      billion: 1e9,
-      t: 1e12,
-      trillion: 1e12,
-    };
-    const n = Number(m[1]) * mult[m[2].toLowerCase()]!;
+    const n = Number(m[1]) * MAGNITUDE_MULTIPLIERS[m[2].toLowerCase()]!;
     return Number.isFinite(n) ? n : null;
   }
   return null;
@@ -117,6 +143,10 @@ export function useNumberField(
     notation !== "scientific" &&
     notation !== "engineering";
 
+  // Serialize formatOptions once per render — it feeds four useMemo dependency
+  // arrays below and JSON.stringify is not free for non-trivial option objects.
+  const formatOptionsKey = JSON.stringify(formatOptions);
+
   const { step = 1, largeStep = step * 10, smallStep = step * 0.1 } = state.options;
 
   const autoId = useId();
@@ -147,7 +177,7 @@ export function useNumberField(
         fixedDecimalScale: effFixedScale,
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [locale, JSON.stringify(formatOptions), prefix, suffix, effMinFrac, effMaxFrac, effFixedScale]
+    [locale, formatOptionsKey, prefix, suffix, effMinFrac, effMaxFrac, effFixedScale]
   );
 
   // Live-typing formatter: keeps grouping + currency symbol but drops the
@@ -173,7 +203,7 @@ export function useNumberField(
         fixedDecimalScale: false,
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [locale, JSON.stringify(formatOptions), prefix, suffix, liveMaxFrac]
+    [locale, formatOptionsKey, prefix, suffix, liveMaxFrac]
   );
 
   const parser = useMemo(
@@ -187,7 +217,7 @@ export function useNumberField(
         suffix,
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [locale, JSON.stringify(formatOptions), allowNegative, allowDecimal, prefix, suffix]
+    [locale, formatOptionsKey, allowNegative, allowDecimal, prefix, suffix]
   );
 
   // Re-format `value` so its integer part groups while the EXACT typed fraction
@@ -221,7 +251,7 @@ export function useNumberField(
       }).format(value);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [formatter, locale, JSON.stringify(formatOptions), prefix, suffix, effMaxFrac]
+    [formatter, locale, formatOptionsKey, prefix, suffix, effMaxFrac]
   );
 
   // ── Cursor engine ────────────────────────────────────────────────────────
@@ -875,17 +905,7 @@ export function useNumberField(
   // registers/unregisters as it mounts, so `aria-labelledby` only points at the
   // label when it truly exists — for any render path (built-in component, custom
   // primitive, or fully headless), not just one that runs a specific effect.
-  const labelCountRef = useRef(0);
-  const [hasLabel, setHasLabel] = useState(false);
-  const labelRef = useCallback<React.RefCallback<HTMLElement>>((node) => {
-    if (node) {
-      labelCountRef.current += 1;
-      setHasLabel(true);
-    } else if (labelCountRef.current > 0) {
-      labelCountRef.current -= 1;
-      if (labelCountRef.current === 0) setHasLabel(false);
-    }
-  }, []);
+  const [hasLabel, labelRef] = useMountedFlag();
 
   // Fall back to the internal label id only when the consumer hasn't supplied
   // their own accessible name AND a label is actually rendered. Defaulting to
@@ -898,17 +918,7 @@ export function useNumberField(
   // aria-describedby points at <NumberField.Description> only while one is
   // actually mounted — avoiding a dangling reference (the same class of bug fixed
   // for aria-labelledby) when no description is rendered.
-  const descCountRef = useRef(0);
-  const [hasDescription, setHasDescription] = useState(false);
-  const descriptionRef = useCallback<React.RefCallback<HTMLElement>>((node) => {
-    if (node) {
-      descCountRef.current += 1;
-      setHasDescription(true);
-    } else if (descCountRef.current > 0) {
-      descCountRef.current -= 1;
-      if (descCountRef.current === 0) setHasDescription(false);
-    }
-  }, []);
+  const [hasDescription, descriptionRef] = useMountedFlag();
 
   // Combine the consumer's own aria-describedby with the internal description id
   // (when present) so the description is announced by assistive technology.

--- a/src/react/useNumberFieldState.ts
+++ b/src/react/useNumberFieldState.ts
@@ -93,6 +93,11 @@ export function useNumberFieldState(options: UseNumberFieldStateOptions): Number
     fixedDecimalScale,
   });
 
+  // Serialize formatOptions once per render — it feeds two useMemo dependency
+  // arrays and the runtime-reformat key below, and JSON.stringify is not free
+  // for non-trivial option objects.
+  const formatOptionsKey = JSON.stringify(formatOptions ?? {});
+
   // ── Formatter & parser (re-created only when deps change) ──────────────────
   const formatter = useMemo(
     () =>
@@ -106,16 +111,7 @@ export function useNumberFieldState(options: UseNumberFieldStateOptions): Number
         fixedDecimalScale: effFixedScale,
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      locale,
-      // JSON-serialize to detect object identity changes
-      JSON.stringify(formatOptions),
-      prefix,
-      suffix,
-      effMinFrac,
-      effMaxFrac,
-      effFixedScale,
-    ]
+    [locale, formatOptionsKey, prefix, suffix, effMinFrac, effMaxFrac, effFixedScale]
   );
 
   const parser = useMemo(
@@ -129,7 +125,7 @@ export function useNumberFieldState(options: UseNumberFieldStateOptions): Number
         suffix,
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [locale, JSON.stringify(formatOptions), allowNegative, allowDecimal, prefix, suffix]
+    [locale, formatOptionsKey, allowNegative, allowDecimal, prefix, suffix]
   );
 
   // ── Controlled/uncontrolled numeric value ──────────────────────────────────
@@ -257,7 +253,7 @@ export function useNumberFieldState(options: UseNumberFieldStateOptions): Number
   // ── Reformat the display when locale / formatOptions change at runtime ──────
   // When the field is not being actively edited, a locale or format change must
   // re-render the existing value in the new format (e.g. switching en-US → de-DE).
-  const formatKey = `${locale ?? ""}|${JSON.stringify(formatOptions ?? {})}|${prefix ?? ""}|${suffix ?? ""}|${effMinFrac ?? ""}|${effMaxFrac ?? ""}|${effFixedScale ?? ""}`;
+  const formatKey = `${locale ?? ""}|${formatOptionsKey}|${prefix ?? ""}|${suffix ?? ""}|${effMinFrac ?? ""}|${effMaxFrac ?? ""}|${effFixedScale ?? ""}`;
   const prevFormatKeyRef = useRef(formatKey);
   if (prevFormatKeyRef.current !== formatKey) {
     prevFormatKeyRef.current = formatKey;


### PR DESCRIPTION
## Summary

Reduces bundle size and runtime cost across the core and React layers, with **no public-API changes**. Two themes:

### 1. Production-strippable dev warnings (the big size win)
Three verbose, user-facing strings shipped in **every** build — including production. The root cause was a runtime `IS_PRODUCTION` const with inverted logic (`if (IS_PRODUCTION) return`), which **defeats dead-code elimination**, so no bundler (nor raqam's own minifier) could ever remove them.

They're now wrapped in the canonical, DCE-friendly guard:

```ts
if (typeof process !== "undefined" && process.env && process.env.NODE_ENV !== "production") { … }
```

- **`formatter.ts`** — invalid-`formatOptions` fallback warning (now also passes the error as a `console.warn` 2nd arg instead of stringifying it: smaller *and* preserves the Error object).
- **`useControllableState.ts`** — controlled/uncontrolled-switch warning (static message replacing dynamic interpolation).
- **`context.ts`** — full guidance in dev, a short identifiable `[raqam] <NumberField.Root> missing` in production.

`dist` still ships the guards, so a consumer's **dev** build keeps the warnings; every production bundler statically strips the guarded branch. Verified that `dist` retains the strings and that a production-minified build (`define: process.env.NODE_ENV=production`) ships **zero** dev-warning strings. The `process.env &&` short-circuit preserves the original crash-safety under partial `process` shims (the access sits on the eliminated side of the token, so it costs nothing in production).

### 2. Cheaper renders & keystrokes
- Cache `JSON.stringify(formatOptions)` **once per render** instead of recomputing it in every `useMemo` dependency array — was up to **7 calls/render** across `useNumberFieldState` + `useNumberField`.
- Remove a redundant `normalizeDigits` pass on **every keystroke** in the cursor engine (`countAcceptedBefore`'s sole caller already normalizes).
- Dedupe the byte-identical label/description mount-tracking into one `useMountedFlag` hook.
- Hoist the compact-notation multiplier map out of the paste hot path.

## Size impact (min + brotli, official `size-limit`)

| Bundle | Before | After |
|---|---|---|
| `raqam/core` | 2.37 kB | **2.23 kB** |
| `raqam` (full) | 9.84 kB | **9.62 kB** |
| `raqam/react` | 9.69 kB | **9.42 kB** |

All bundles remain comfortably under their `size-limit` budgets.

## Reviewer notes
- **Behavior change (dev-only, documented):** under raw-browser ESM (no bundler, `process` undefined), all three dev diagnostics are now gated off, and the missing-`Root` error degrades to the short message. Bundler users get the full warnings in development as before. This is the inherent trade-off of making the warnings statically strippable.
- No test asserts the warning/error text; tests run with `NODE_ENV !== "production"` so the dev branches fire normally.
- An adversarial multi-agent review (behavior-preservation / DCE & cross-bundler safety / dev-DX & TypeScript soundness) surfaced the `process`-without-`env` crash-safety gap, which this PR fixes via `process.env &&`. No confirmed blockers remained.

## Verification
- ✅ **684/684 unit tests pass**
- ✅ `tsc --noEmit` clean
- ✅ `publint` clean
- ✅ biome (via pre-commit lint-staged) clean
- ✅ `dist` confirmed to still carry the guarded warnings for consumer dev builds; production-minified output ships zero dev-warning strings
- ✅ Crash-safety re-verified: a `process` shim without `.env` no longer throws

A changeset (`patch`) is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)