### PR TITLE
docs: ship a social card and correct every stale bundle-size claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Measured min + brotli (including dependencies), enforced in CI via
 |-------|------|-----------|
 | `raqam/core` | ~2.23 KB | 2.5 KB |
 | `raqam` (hooks + components) | ~9.62 KB | 12 KB |
-| `raqam/react` | ~9.42 KB | 10 KB |
+| `raqam/react` | ~9.48 KB | 10 KB |
 | `raqam/locales/fa` | 196 B | 0.3 KB |
 
 ## 📄 License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported versions
+
+raqam is pre-1.0. Security fixes land on the latest published minor only —
+upgrade before reporting against an older release.
+
+| Version | Supported |
+| ------- | --------- |
+| 0.4.x   | ✅        |
+| < 0.4   | ❌        |
+
+## Reporting a vulnerability
+
+Report privately through GitHub's
+[**Report a vulnerability**](https://github.com/47vigen/raqam/security/advisories/new)
+form. Please do not open a public issue for a suspected vulnerability.
+
+Include the raqam version, the affected entry point (`raqam`, `raqam/core`,
+`raqam/react`, `raqam/locales/*`), and a minimal reproduction.
+
+You can expect an acknowledgement within 72 hours and, for a confirmed issue, a
+patched release plus a published advisory.
+
+## Scope
+
+raqam ships **zero runtime dependencies** — nothing in this repository's
+dependency tree reaches a consumer of the package. Advisories against dev
+tooling (vite, storybook, playwright and friends) therefore do not affect
+anyone who installs raqam, and are tracked in `pnpm-workspace.yaml` under
+`auditConfig` rather than patched on an emergency basis.
+
+In scope: anything in `src/` that ships in `dist/` — the parser, formatter,
+cursor logic, locale plugins, and the React bindings. The library renders no
+HTML from user input and performs no network or filesystem access.

--- a/docs/app/(home)/page.tsx
+++ b/docs/app/(home)/page.tsx
@@ -41,11 +41,13 @@ const FEATURES = [
   },
 ]
 
+// Measured min+brotli by `pnpm size`; bars are scaled against the 12 KB
+// full-bundle budget. Refresh both columns whenever size-limit output moves.
 const BUNDLE = [
-  { name: "raqam/core", size: "~1.84 KB", w: "16%" },
-  { name: "raqam/react", size: "~8.1 KB", w: "68%" },
-  { name: "raqam (full)", size: "~8.3 KB", w: "70%" },
-  { name: "raqam/locales/fa", size: "189 B", w: "4%" },
+  { name: "raqam/core", size: "~2.23 KB", w: "19%" },
+  { name: "raqam/react", size: "~9.48 KB", w: "79%" },
+  { name: "raqam (full)", size: "~9.62 KB", w: "80%" },
+  { name: "raqam/locales/fa", size: "196 B", w: "4%" },
 ]
 
 const EXAMPLE = `import { NumberField } from "raqam";
@@ -91,7 +93,7 @@ export default function HomePage() {
         <div className={`${container} grid items-center gap-12 py-16 lg:grid-cols-[1.05fr_0.95fr] lg:py-24`}>
           <div className="flex flex-col items-start gap-6">
           <span className="animate-rise">
-            <Eyebrow>Headless · i18n · ~1.8 KB</Eyebrow>
+            <Eyebrow>Headless · i18n · ~2.2 KB</Eyebrow>
           </span>
           <h1 className="animate-rise font-display text-5xl font-bold leading-[0.98] tracking-[-0.03em] text-fd-foreground sm:text-6xl">
             The number input,
@@ -102,7 +104,7 @@ export default function HomePage() {
             <b className="font-semibold text-fd-foreground">Live formatting</b>,{" "}
             <b className="font-semibold text-fd-foreground">full i18n</b>,{" "}
             <b className="font-semibold text-fd-foreground">headless</b>, and{" "}
-            <b className="font-semibold text-fd-foreground">accessible</b> — in a ~1.8 KB
+            <b className="font-semibold text-fd-foreground">accessible</b> — in a ~2.2 KB
             core. The React number field you stop fighting.
           </p>
           <div className="animate-rise flex flex-wrap items-center gap-3">

--- a/docs/app/opengraph-image.tsx
+++ b/docs/app/opengraph-image.tsx
@@ -1,0 +1,83 @@
+import { ImageResponse } from "next/og"
+import { appName } from "@/lib/shared"
+
+// Inherited by every route, so one card covers the whole site. The layout
+// mirrors assets/raqam-poster.jpg — paper background, goose square, numeral
+// column — but renders live text, so the size claim can't go stale in art.
+export const size = { width: 1200, height: 630 }
+export const contentType = "image/png"
+export const alt = `${appName} — the definitive React number input`
+
+const PAPER = "#faf9f7"
+const INK = "#1b1a17"
+const GOOSE = "#2c5c4c"
+const HAIRLINE = "#dedcd7"
+
+// Plain digit triples only — the grouped Persian form needs U+066C, which the
+// fallback face substitutes into garbage.
+// Arabic ١٢٣ is dropped: the fallback face renders it identically to Persian.
+const NUMERALS = ["1,234.00", "۱۲۳", "१२३", "১২৩"]
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        background: PAPER,
+        color: INK,
+        fontFamily: "sans-serif",
+      }}
+    >
+      <div
+        style={{
+          flex: "1 1 0",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: "0 64px",
+          gap: 18,
+        }}
+      >
+        <div style={{ display: "flex", width: 42, height: 42, background: GOOSE }} />
+        <div style={{ display: "flex", fontSize: 140, fontWeight: 700, letterSpacing: -6 }}>
+          raqam
+        </div>
+        <div style={{ display: "flex", fontSize: 38, color: "#3d3b36" }}>
+          The definitive React number input
+        </div>
+        <div
+          style={{
+            display: "flex",
+            fontSize: 16,
+            letterSpacing: 1.5,
+            color: "#6b6862",
+            fontFamily: "monospace",
+          }}
+        >
+          LIVE FORMATTING · FULL I18N · HEADLESS · ACCESSIBLE · ~2.2 KB
+        </div>
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          gap: 22,
+          width: 340,
+          padding: "0 52px",
+          borderLeft: `2px solid ${HAIRLINE}`,
+        }}
+      >
+        {NUMERALS.map((n) => (
+          <div key={n} style={{ display: "flex", fontSize: 46, color: "#93a89f" }}>
+            {n}
+          </div>
+        ))}
+      </div>
+    </div>,
+    size,
+  )
+}

--- a/docs/content/docs/guides/locales.mdx
+++ b/docs/content/docs/guides/locales.mdx
@@ -63,7 +63,7 @@ the plugin, `۱۲۳` is accepted and internally treated as `123`.
 import "raqam/locales";   // imports fa, ar, hi, bn, th
 ```
 
-Each plugin is tiny — well under 200 B (e.g. `raqam/locales/fa` is 189 B, min +
+Each plugin is tiny — well under 200 B (e.g. `raqam/locales/fa` is 196 B, min +
 brotli), enforced in CI via `.size-limit.json`.
 
 ### Locale metadata exports

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -6,7 +6,7 @@ description: The definitive React number input — live formatting, full i18n, h
 import { Pencil, Languages, Puzzle, CircleCheck } from "lucide-react";
 
 **raqam** is a headless React number input with live, cursor-stable formatting, full
-internationalization, and first-class accessibility — in a ~1.8 KB core.
+internationalization, and first-class accessibility — in a ~2.2 KB core.
 
 Every other React number input forces a trade-off. raqam eliminates all four.
 
@@ -79,7 +79,7 @@ Measured min + brotli (including dependencies), enforced in CI:
 
 | Import             | Size     | CI budget |
 | ------------------ | -------- | --------- |
-| `raqam/core`       | ~1.84 KB | 2 KB      |
-| `raqam` (full)     | ~8.3 KB  | 12 KB     |
-| `raqam/react`      | ~8.1 KB  | 10 KB     |
-| `raqam/locales/fa` | 189 B    | 0.3 KB    |
+| `raqam/core`       | ~2.23 KB | 2.5 KB    |
+| `raqam` (full)     | ~9.62 KB | 12 KB     |
+| `raqam/react`      | ~9.48 KB | 10 KB     |
+| `raqam/locales/fa` | 196 B    | 0.3 KB    |


### PR DESCRIPTION
Launch-readiness pass over what a visitor and a tweet actually see.

## The social card was declared but missing

`docs/app/layout.tsx` set `twitter: { card: "summary_large_image" }` and an `openGraph` block — with no image anywhere in the project. Sharing `raqam.47vigen.com` on X, Slack, or Discord rendered a large-image card with a blank image well.

Added `docs/app/opengraph-image.tsx`. It's Next's file convention, so it's inherited by every route — verified `og:image`, `og:image:width/height/alt`, `twitter:image` and `twitter:image:alt` now resolve on `/` and on `/docs/*`, across all 49 static pages.

It redraws the poster layout (paper, goose square, numeral column) with **live text** instead of baked art — which is exactly what let the size claim go stale in the first place.

<img width="600" alt="raqam social card" src="https://raqam.47vigen.com/opengraph-image" />

## Every size figure on the docs site was stale

The headline claim of this library is bundle size, and the site was a release or two behind what `pnpm size` actually measures. Someone checking bundlephobia on launch day would have caught it.

| | claimed | measured | CI budget |
|---|---|---|---|
| `raqam/core` | ~1.84 KB | **~2.23 KB** | 2.5 KB (site said 2 KB) |
| `raqam` (full) | ~8.3 KB | **~9.62 KB** | 12 KB |
| `raqam/react` | ~8.1 KB | **~9.48 KB** | 10 KB |
| `raqam/locales/fa` | 189 B | **196 B** | 0.3 KB |

Plus `~1.8 KB core` in the hero eyebrow, the hero paragraph, and the docs Overview intro. The README table was already correct except `raqam/react` (~9.42 → ~9.48 KB).

## SECURITY.md

The repo had no security policy. Adds private reporting through GitHub advisories and the scope note that matters here: raqam ships **zero runtime dependencies**, so dev-tooling advisories never reach anyone who installs it.

## Verified

- `pnpm docs:build` — 49 static pages, `/opengraph-image` among them
- docs `typecheck` — pass
- OG/Twitter meta asserted on `/` and `/docs/getting-started`
- Card rendered and inspected at 1200×630

## Still needs you

`assets/raqam-poster.jpg` has `~1.8 KB` baked into the artwork. It's the README hero and the npm package image, so it's the most-seen asset of the launch — but it needs re-exporting from the design source, which I don't have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)