### PR TITLE
fix(core): render non-finite values as empty in formatToParts and formatResult

### DIFF
--- a/.changeset/formatter-non-finite-parts.md
+++ b/.changeset/formatter-non-finite-parts.md
@@ -1,0 +1,9 @@
+---
+"raqam": patch
+---
+
+`formatToParts` and `formatResult` now render non-finite values as nothing,
+matching `format`. Previously `format(NaN)` returned `""` while
+`formatResult(NaN).formatted` returned `"NaN"` — and a configured
+`prefix`/`suffix` was wrapped around it. Only reachable through `raqam/core`
+directly; the React bindings never format a non-finite value.

--- a/src/core/formatter.test.ts
+++ b/src/core/formatter.test.ts
@@ -26,6 +26,24 @@ describe("createFormatter", () => {
     });
   });
 
+  // formatToParts/formatResult must agree with format(), which renders
+  // non-finite values as nothing rather than "NaN"/"∞".
+  describe("non-finite values", () => {
+    const fmt = createFormatter({ locale: "en-US", prefix: "$", suffix: " USD" });
+
+    for (const value of [NaN, Infinity, -Infinity]) {
+      it(`renders ${value} as empty across format, formatToParts and formatResult`, () => {
+        expect(fmt.format(value)).toBe("");
+        expect(fmt.formatToParts(value)).toEqual([]);
+        expect(fmt.formatResult(value)).toEqual({ formatted: "", parts: [] });
+      });
+    }
+
+    it("still emits affixes for finite values", () => {
+      expect(fmt.formatResult(12).formatted).toBe("$12 USD");
+    });
+  });
+
   describe("format — de-DE", () => {
     const fmt = createFormatter({ locale: "de-DE" });
 

--- a/src/core/formatter.ts
+++ b/src/core/formatter.ts
@@ -193,6 +193,9 @@ export function createFormatter(opts: FormatterOptions): Formatter {
   }
 
   function formatToParts(value: number): Intl.NumberFormatPart[] {
+    // Match format(): non-finite renders as nothing, not "NaN"/"∞" — and never
+    // wrapped in a prefix/suffix.
+    if (!Number.isFinite(value)) return [];
     const parts = intlFmt.formatToParts(value);
     if (!opts.prefix && !opts.suffix) return parts;
 


### PR DESCRIPTION
Found while reviewing `src/core` for the launch.

`format()` has always returned `""` for `NaN` / `±Infinity`, and `formatter.test.ts` pins that behaviour. But `formatToParts()` passed straight through to `Intl.NumberFormat`, so the same input came back as `[{ type: "nan", value: "NaN" }]` — and `formatResult()`, which is built on it, reported `{ formatted: "NaN" }`. With `prefix`/`suffix` configured, the affixes were wrapped around it: `"$NaN USD"`.

```ts
const fmt = createFormatter({ locale: "en-US", prefix: "$" })
fmt.format(NaN)                 // "" ✅
fmt.formatResult(NaN).formatted // "$NaN" ❌ — now ""
```

**Blast radius is small.** Only reachable through `raqam/core` directly — the React bindings guard on `Number.isFinite` before anything reaches a formatter (`useNumberField.ts`, `useNumberFieldState.ts`), which is why no existing test caught it. Still worth fixing before promotion: `formatToParts` / `formatResult` are documented public API in [core-utilities](https://raqam.47vigen.com/docs/api/core-utilities), and an inconsistent contract is the kind of thing an early adopter files first.

One guard in `formatToParts`; `formatResult` inherits it.

## Verified

- 688 unit tests pass (4 new, covering `NaN` / `Infinity` / `-Infinity` across all three methods, plus a regression check that affixes still emit for finite values)
- `typecheck` and `lint` clean
- Changeset added (patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)