### PR TITLE
docs(readme): compare like for like in the bundle-size row

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 | Truly headless | ✅ | ✅ | ❌ | ✅ |
 | i18n digit input (Persian ۱۲۳, Arabic ١٢٣…) | ❌ | ✅ | ❌ | ✅ |
 | WAI-ARIA spinbutton | ✅ | ✅✅ | ⚠️ | ✅✅ |
-| Bundle size | ~10 KB | ~30 KB | ~60 KB | **~2.2 KB core** |
+| Bundle size | ~10 KB | ~30 KB | ~60 KB | **~2.2 KB core · ~9.6 KB full** |
 
 No existing package combines all four. raqam does.
 


### PR DESCRIPTION
The "Why raqam?" table put raqam's **core** (2.2 KB — the headless engine, no React bindings) against Base UI / React Aria / Mantine's **full component packages**. That's the comparison someone screenshots and replies to on launch day.

```diff
-| Bundle size | ~10 KB | ~30 KB | ~60 KB | **~2.2 KB core** |
+| Bundle size | ~10 KB | ~30 KB | ~60 KB | **~2.2 KB core · ~9.6 KB full** |
```

Naming both figures is the claim that survives someone opening bundlephobia — and ~9.6 KB still wins the row outright.

Also verified along the way, against the **published** `raqam@0.4.2` from npm in a clean project:

- all six entry points resolve — `raqam`, `/core`, `/react`, `/locales`, `/locales/fa`, `/server` — from both ESM `import` and CJS `require`
- every named export the README quick-start uses is present
- `createFormatter`/`createParser` round-trip `$1,234.56` in en-US and `1.234,56` in de-DE
- fa-IR formats to Persian digits, and parses back from both `۱٬۲۳۴` and `1234`

🤖 Generated with [Claude Code](https://claude.com/claude-code)