### PR TITLE
feat: make raqam legible to coding agents

### DIFF
--- a/.changeset/agent-readable-types.md
+++ b/.changeset/agent-readable-types.md
@@ -1,0 +1,10 @@
+---
+"raqam": patch
+---
+
+Document the public React surface with JSDoc that ships in the type
+declarations. `NumberField` and each of its twelve parts, plus
+`useNumberFieldState` and `useNumberField`, now carry composition rules and
+runnable examples — so editor hover and any tool reading
+`node_modules/raqam/dist/*.d.ts` gets the API without a network round-trip.
+Types only; no runtime change.

--- a/.changeset/input-ref-forwarding.md
+++ b/.changeset/input-ref-forwarding.md
@@ -1,0 +1,9 @@
+---
+"raqam": patch
+---
+
+`NumberField.Input` now populates a consumer `ref`. It was declared with
+`forwardRef` but ignored the forwarded ref, assigning only the internal caret
+ref — so `<NumberField.Input ref={myRef} />` type-checked and left `myRef.current`
+null forever. The consumer ref is merged alongside the internal one, so focus and
+selection work without unwiring caret control or scrubbing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,86 @@
+# AGENTS.md
+
+Conventions for coding agents working **in this repository**.
+
+> **Just want to *use* raqam in another project?** You don't need this file.
+> Read [`skills/raqam/SKILL.md`](skills/raqam/SKILL.md), or point your agent at
+> <https://raqam.47vigen.com/llms.txt> (index) or
+> <https://raqam.47vigen.com/llms-full.txt> (every page, one file). The shipped
+> `.d.ts` files carry JSDoc with runnable examples, so hovering `NumberField` in
+> an editor is often enough.
+
+## What this is
+
+`raqam` — a headless React number input with live, cursor-stable formatting and
+i18n digit support. Published to npm, MIT, **zero runtime dependencies**. React
+18/19 are peer deps. Node ≥20.9, pnpm 10.
+
+## Layout
+
+| Path | What lives there |
+| --- | --- |
+| `src/core/` | No React. Formatter, parser, cursor math, digit normalizer, presets. Ships as `raqam/core` and `raqam/server`. |
+| `src/react/` | Hooks and the `NumberField` compound components. Ships as `raqam/react`. |
+| `src/locales/` | Side-effect digit plugins (`fa`, `ar`, `bn`, `hi`, `th`). |
+| `src/stories/` | Storybook, snapshotted by Chromatic. |
+| `e2e/` | Playwright **component** tests — real browsers, for caret and RTL behaviour. |
+| `docs/` | The Next.js + Fumadocs site. Separate workspace package, not published. |
+| `skills/raqam/` | The installable agent skill. Keep in sync with the API. |
+| `DEFINITION.md` | Historical design spec written *before* implementation. Rationale, not API docs — do not treat it as current. |
+
+## Verifying your work
+
+`pnpm lint` is **read-only** (`biome check src/`); `pnpm lint:fix` writes. Never
+use a writing command as a gate.
+
+```bash
+pnpm typecheck   # tsc --noEmit
+pnpm test        # vitest run
+pnpm lint        # biome check src/
+pnpm build       # tsup — must succeed before publint/size
+pnpm publint     # export map validity
+pnpm size        # size-limit budgets, enforced in CI
+pnpm test:e2e    # Playwright CT — needs `pnpm exec playwright install` once
+```
+
+`pnpm lint` currently reports ~34 warnings (exhaustive-deps on
+deliberately mount-only memos, non-null assertions the surrounding code proves).
+They are known and do not fail CI — don't "fix" them by changing behaviour.
+
+## Rules that bite
+
+- **TypeScript stays on 5.x.** 6.x and 7.x break the `.d.ts` build: tsup's
+  `rollup-plugin-dts` reads the old compiler API and dies on
+  `useCaseSensitiveFileNames`. Do not bump it, in either package.
+- **Never add a runtime dependency.** Zero deps is a headline claim, a security
+  boundary, and what keeps the core at ~2.2 KB.
+- **Public API changes need a changeset** (`pnpm changeset`). Releases are
+  automated from `main`; merging the "Version Packages" PR publishes to npm.
+- **JSDoc on the public surface must sit on the exported object's properties**,
+  not on the internal `const`. Declaration emit synthesizes the `NumberField`
+  object type and drops docs attached to the individual components. That JSDoc
+  is what an agent reads in a consumer's `node_modules` — treat it as shipped
+  documentation, not comments.
+- **Size budgets are enforced.** `.size-limit.json` fails CI on a regression.
+- **Bundle-size figures appear in four places** — `README.md`,
+  `docs/content/docs/index.mdx`, `docs/app/(home)/page.tsx`, and
+  `docs/content/docs/guides/locales.mdx`. Update all of them together from
+  `pnpm size` output.
+
+## Branches and commits
+
+Default branch `main`, never committed to directly. Branch as `claude/*`,
+`fix/*`, `feat/*`, `docs/*`, `chore/*`, and open a PR.
+
+Conventional Commits with a scope, enforced by commitlint:
+`fix(core):`, `feat(react):`, `docs(readme):`, `chore(deps):`, `ci:`.
+
+## Docs site
+
+`pnpm docs:dev` runs it; `pnpm docs:build` builds it (the library is built
+first by `docs/scripts/build-lib.mjs`). Machine-readable surfaces that must keep
+working: `/llms.txt`, `/llms-full.txt`, `/api/md/*`, and `/opengraph-image`.
+
+Page markdown comes from `page.data.getText("processed")`. The older
+`page.data._markdown` field returns `undefined` in fumadocs-mdx 15 and fails
+silently — it served title-only pages for a while.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,12 @@ Conventions for coding agents working **in this repository**.
 
 `raqam` — a headless React number input with live, cursor-stable formatting and
 i18n digit support. Published to npm, MIT, **zero runtime dependencies**. React
-18/19 are peer deps. Node ≥20.9, pnpm 10.
+18/19 are peer deps. pnpm 10.
+
+Two different Node floors, don't conflate them: the **published package**
+supports Node ≥20.9 (`engines.node`), while **developing on this repo** needs
+Node 22+ — `jsdom@30`, the vitest environment, requires
+`^22.22.2 || ^24.15.0 || >=26.0.0`. `.nvmrc` pins 22 and CI reads it.
 
 ## Layout
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,15 @@
 
 ## Development setup
 
+**Node 22+** (`.nvmrc` pins it; `jsdom`, the test environment, requires
+`^22.22.2 || ^24.15.0 || >=26.0.0`) and **pnpm 10**. Note this is the floor for
+*developing on* raqam — the published package still supports Node ≥20.9.
+
 ```bash
 # Clone and install
 git clone https://github.com/47vigen/raqam.git
 cd raqam
+nvm use            # or any Node 22+
 pnpm install
 
 # Run tests in watch mode

--- a/README.md
+++ b/README.md
@@ -363,6 +363,26 @@ Every component accepts a `render` prop for element replacement:
 )} />
 ```
 
+## 🤖 Using raqam with an AI agent
+
+raqam is built to be readable by coding agents, not just people:
+
+- **[`llms.txt`](https://raqam.47vigen.com/llms.txt)** — an index of every docs
+  page with a raw-markdown URL each. **[`llms-full.txt`](https://raqam.47vigen.com/llms-full.txt)**
+  is the whole corpus in one request. Any page is available as markdown at
+  `https://raqam.47vigen.com/api/md/<path>`.
+- **JSDoc on the shipped types** — hovering `NumberField` in an editor, or
+  reading `node_modules/raqam/dist/*.d.ts`, gives the composition rules and
+  runnable examples with no network access.
+- **An installable skill** — [`skills/raqam`](skills/raqam/SKILL.md) leads with
+  working code and the mistakes worth avoiding:
+
+  ```bash
+  npx skills add https://github.com/47vigen/raqam/tree/main/skills/raqam
+  ```
+
+Contributing with an agent? See [`AGENTS.md`](AGENTS.md).
+
 ## 📦 Bundle size
 
 Measured min + brotli (including dependencies), enforced in CI via

--- a/docs/app/api/md/[[...slug]]/route.ts
+++ b/docs/app/api/md/[[...slug]]/route.ts
@@ -15,7 +15,9 @@ export async function GET(
   const page = source.getPage(slug)
   if (!page) notFound()
 
-  const md = (page.data as { _markdown?: string })._markdown ?? ""
+  // `getText("processed")` — reading `page.data._markdown` returns undefined in
+  // fumadocs-mdx 15, which silently served title-only pages.
+  const md = await page.data.getText("processed")
   const body = `# ${page.data.title}\n\n${page.data.description ?? ""}\n\n${md}`.trim()
 
   return new Response(body, {

--- a/docs/app/llms-full.txt/route.ts
+++ b/docs/app/llms-full.txt/route.ts
@@ -1,0 +1,37 @@
+import { source } from "@/lib/source"
+import { appDescription, appName } from "@/lib/shared"
+
+// The whole docs corpus in one request, for agents that would rather read once
+// than crawl the index at /llms.txt.
+export const dynamic = "force-static"
+
+export async function GET() {
+  const pages = source
+    .getPages()
+    .slice()
+    .sort((a, b) => a.url.localeCompare(b.url))
+
+  const body = [
+    `# ${appName} — full documentation`,
+    "",
+    `> ${appDescription}`,
+    "",
+    ...(await Promise.all(
+      pages.map(async (page) =>
+        [
+          "---",
+          "",
+          `# ${page.data.title}`,
+          page.data.description ? `\n${page.data.description}` : "",
+          "",
+          await page.data.getText("processed"),
+          "",
+        ].join("\n"),
+      ),
+    )),
+  ].join("\n")
+
+  return new Response(body, {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  })
+}

--- a/docs/app/llms.txt/route.ts
+++ b/docs/app/llms.txt/route.ts
@@ -1,0 +1,63 @@
+import { getMarkdownUrl, source } from "@/lib/source"
+import { appDescription, appName, githubUrl, siteUrl } from "@/lib/shared"
+
+// https://llmstxt.org — an index an agent can read in one request, pointing at
+// the raw-markdown route for every page. See ./llms-full.txt for the whole
+// corpus inlined.
+export const dynamic = "force-static"
+
+// A page's first path segment is its section; keep the order the sidebar uses.
+const SECTION_TITLES: Record<string, string> = {
+  "": "Start here",
+  api: "API reference",
+  guides: "Guides",
+  recipes: "Recipes",
+}
+const SECTION_ORDER = ["", "api", "guides", "recipes"]
+
+export function GET() {
+  const pages = source.getPages()
+
+  const bySection = new Map<string, string[]>()
+  for (const page of pages) {
+    const section = page.slugs.length > 1 ? page.slugs[0] : ""
+    const line = `- [${page.data.title}](${siteUrl}${getMarkdownUrl(page.slugs)}): ${
+      page.data.description ?? ""
+    }`.trimEnd()
+    bySection.set(section, [...(bySection.get(section) ?? []), line])
+  }
+
+  const sections = [...bySection.keys()].sort(
+    (a, b) => SECTION_ORDER.indexOf(a) - SECTION_ORDER.indexOf(b),
+  )
+
+  const body = [
+    `# ${appName}`,
+    "",
+    `> ${appDescription} Zero runtime dependencies, ~2.2 KB core, React 18/19.`,
+    "",
+    "Import `NumberField` for the compound components, or `useNumberFieldState`",
+    "+ `useNumberField` to own the DOM. Configure formatting on `NumberField.Root`",
+    "(`locale`, `formatOptions` — passed to `Intl.NumberFormat`), never on `Input`.",
+    "Native `<form>` submission needs `name` on `Root` plus `<NumberField.HiddenInput />`,",
+    "because the visible input holds the formatted string. Typing non-Latin digits",
+    "needs a side-effect import: `import \"raqam/locales/fa\"` (also `ar`, `bn`, `hi`, `th`).",
+    "",
+    ...sections.flatMap((section) => [
+      `## ${SECTION_TITLES[section] ?? section}`,
+      "",
+      ...(bySection.get(section) ?? []).sort(),
+      "",
+    ]),
+    "## Optional",
+    "",
+    `- [Full documentation, inlined](${siteUrl}/llms-full.txt): every page above as one file`,
+    `- [Repository](${githubUrl}): source, issues, and an installable agent skill under \`skills/raqam\``,
+    `- [AGENTS.md](${githubUrl}/blob/main/AGENTS.md): conventions for agents working in this repo`,
+    "",
+  ].join("\n")
+
+  return new Response(body, {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  })
+}

--- a/docs/components/playground/playground-templates.ts
+++ b/docs/components/playground/playground-templates.ts
@@ -140,6 +140,7 @@ export default function App() {
   return (
     <div className="field">
       <NumberField.Root
+        name="price"
         locale="en-US"
         formatOptions={{ style: "currency", currency: "USD" }}
         defaultValue={1234.56}
@@ -152,8 +153,9 @@ export default function App() {
           <NumberField.Input />
           <NumberField.Increment>+</NumberField.Increment>
         </NumberField.Group>
-        {/* Submits the raw number, not the formatted string. */}
-        <NumberField.HiddenInput name="price" />
+        {/* Submits the raw number, not the formatted string.
+            Needs name="price" on Root — HiddenInput takes no props. */}
+        <NumberField.HiddenInput />
       </NumberField.Root>
     </div>
   );

--- a/docs/content/docs/api/components.mdx
+++ b/docs/content/docs/api/components.mdx
@@ -245,23 +245,38 @@ If you also pass `aria-describedby` on `<NumberField.Input>`, your value is
 
 ## `NumberField.ErrorMessage`
 
-Displays validation errors. Has `role="alert"` and is only shown when the field
-is invalid.
+Displays validation errors. Has `role="alert"`.
 
-If you pass no children, it renders `state.validationError` automatically:
+If you pass no children, it renders `state.validationError` automatically —
+and nothing while the field is valid:
 
 ```tsx
 <NumberField.ErrorMessage />
 {/* Renders: "Must be a positive number" */}
 ```
 
-Or supply your own content:
+Or supply your own content — but then **you own visibility**. Children render
+whenever they are truthy, valid field or not, so gate them yourself with
+[`useNumberFieldContext`](/docs/api/advanced-primitives) or you leave a
+permanent `role="alert"` on screen:
 
 ```tsx
-<NumberField.ErrorMessage>
-  Custom error text.
-</NumberField.ErrorMessage>
+function CustomError() {
+  const { state } = useNumberFieldContext()
+  if (state.validationState !== "invalid") return null
+  return <NumberField.ErrorMessage>Custom error text.</NumberField.ErrorMessage>
+}
+
+<NumberField.Root
+  locale="en-US"
+  validate={(v) => (v !== null && v > 0 ? true : "Must be positive")}
+>
+  <NumberField.Input />
+  <CustomError />
+</NumberField.Root>
 ```
+
+`ErrorMessage` does not accept a `render` prop.
 
 ---
 

--- a/skills/raqam/SKILL.md
+++ b/skills/raqam/SKILL.md
@@ -5,14 +5,72 @@ description: Teaches the raqam React number-input library — headless NumberFie
 
 # raqam (React number input)
 
+## Start here — this is a complete, working answer
+
+If the request is "build me a number field with raqam", write this. It needs no
+further reading and no network access.
+
+```bash
+npm install raqam   # peer deps: react, react-dom (18 or 19)
+```
+
+```tsx
+import { NumberField } from "raqam";
+
+export function QuantityField() {
+  return (
+    <NumberField.Root locale="en-US" defaultValue={1} minValue={0} maxValue={99}>
+      <NumberField.Label>Quantity</NumberField.Label>
+      <NumberField.Group>
+        <NumberField.Decrement>−</NumberField.Decrement>
+        <NumberField.Input />
+        <NumberField.Increment>+</NumberField.Increment>
+      </NumberField.Group>
+    </NumberField.Root>
+  );
+}
+```
+
+Vary it by changing **`Root`**, never `Input`:
+
+| Want | Change |
+|------|--------|
+| Currency | `formatOptions={{ style: "currency", currency: "USD" }}` |
+| Percent | `formatOptions={{ style: "percent" }}` — stores the fraction (`42%` ⇒ `0.42`) |
+| Persian / Arabic digits | `locale="fa-IR"` **plus** `import "raqam/locales/fa"` |
+| Native `<form>` submit | `name="price"` on `Root` **plus** `<NumberField.HiddenInput />` |
+| Controlled | `value` + `onValueChange` instead of `defaultValue` |
+| Settled value only | `onValueCommitted` (fires on blur/Enter) |
+
+raqam ships **no styles**. Every part forwards `className`, `style` and refs.
+In a Tailwind project, style `Group` for the border and `Input` for the text;
+`Root` exposes `data-focused`, `data-invalid`, `data-disabled`, `data-readonly`,
+`data-required`, `data-scrubbing`, and `Input` exposes `data-rtl`.
+
+Four mistakes to avoid:
+
+1. Putting `locale` / `formatOptions` / `value` / `onChange` on `Input`. They go on `Root`.
+2. Setting `type="number"` on `Input` — it is fixed to `text` + `inputMode="decimal"`, because `type="number"` defeats formatting.
+3. Reordering `Decrement, Input, Increment`. RTL flips them visually on its own.
+4. Expecting a plain `<form>` POST to send the number. The visible input holds the *formatted* string; add `HiddenInput`.
+
+Everything below is for cases this block does not cover.
+
 ## Canonical sources (read these for full detail)
 
+- **Docs index for agents:** [https://raqam.47vigen.com/llms.txt](https://raqam.47vigen.com/llms.txt) — every page, with a raw-markdown URL each
+- **Whole docs corpus in one file:** [https://raqam.47vigen.com/llms-full.txt](https://raqam.47vigen.com/llms-full.txt)
+- **Any page as raw markdown:** append the path to `/api/md/` — e.g. [`/api/md/api/components`](https://raqam.47vigen.com/api/md/api/components)
 - **Docs site:** [https://raqam.47vigen.com](https://raqam.47vigen.com)
 - **README (quick API tables):** [https://github.com/47vigen/raqam/blob/main/README.md](https://github.com/47vigen/raqam/blob/main/README.md)
 - **Package:** [https://www.npmjs.com/package/raqam](https://www.npmjs.com/package/raqam)
 - **Issues:** [https://github.com/47vigen/raqam/issues](https://github.com/47vigen/raqam/issues)
 
-Do not assume paths inside the raqam repo; always prefer the docs URLs above. Version in this skill reflects the library at publish time; confirm the current version on npm.
+The installed package's `.d.ts` files carry JSDoc with runnable examples — if
+you already have `raqam` in `node_modules`, reading the types is faster and more
+reliable than fetching anything. Do not guess at paths inside the raqam repo;
+prefer the URLs above. Version numbers in this skill reflect publish time;
+confirm the current version on npm.
 
 ## What raqam is
 
@@ -127,10 +185,13 @@ Avoid steering users toward undocumented or stale APIs when a documented path al
 
 ## When the model needs more detail
 
-1. Open the **exact doc page** from the links above (prefer over guessing APIs).
-2. Use **Context7** / current package docs for npm `raqam` if behavior vs version matters.
-3. For exhaustive option tables and extra props, see [reference.md](reference.md).
-4. For copy-paste patterns, see [examples.md](examples.md).
+Cheapest first:
+
+1. **Read the installed types** — `node_modules/raqam/dist/*.d.ts` carry JSDoc with examples. No network, always matches the installed version.
+2. For copy-paste patterns, see [examples.md](examples.md); for exhaustive option tables, [reference.md](reference.md).
+3. Fetch the **exact doc page** as markdown: `https://raqam.47vigen.com/api/md/<path>` (prefer over guessing APIs).
+4. Need everything at once? [llms-full.txt](https://raqam.47vigen.com/llms-full.txt).
+5. Use **Context7** / current package docs for npm `raqam` if behavior vs version matters.
 
 ## Docs site map (official)
 

--- a/src/react/NumberField.test.tsx
+++ b/src/react/NumberField.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
+import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { NumberField } from "./NumberField.js";
@@ -219,6 +220,27 @@ describe("NumberField ARIA attributes", () => {
     expect(labelId).toBeTruthy();
     expect(screen.getByTestId("group")).toHaveAttribute("aria-labelledby", labelId);
     expect(screen.getByTestId("input")).toHaveAttribute("aria-labelledby", labelId);
+  });
+
+  it("populates a consumer ref on Input without unwiring caret control", async () => {
+    // Input declared forwardRef but ignored it, so `ref` type-checked and
+    // silently stayed null. The context ref drives caret control and scrubbing,
+    // so both must attach.
+    const myRef = React.createRef<HTMLInputElement>();
+    render(
+      <NumberField.Root locale="en-US" defaultValue={1000}>
+        <NumberField.Input data-testid="input" ref={myRef} />
+      </NumberField.Root>
+    );
+
+    expect(myRef.current).toBeInstanceOf(HTMLInputElement);
+    expect(myRef.current).toBe(screen.getByTestId("input"));
+
+    // Caret control still works — it reads the context ref, not the consumer's.
+    const input = screen.getByTestId("input") as HTMLInputElement;
+    await userEvent.click(input);
+    await userEvent.keyboard("{End}5");
+    expect(input.value).toBe("10,005");
   });
 
   it("runs a consumer ref's React 19 cleanup function on unmount", () => {

--- a/src/react/NumberField.tsx
+++ b/src/react/NumberField.tsx
@@ -280,9 +280,13 @@ interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "
 
 const Input = forwardRef<HTMLInputElement, InputProps>(function NumberFieldInput(
   { render, ...rest },
-  _ref
+  ref
 ) {
   const { aria, state, inputRef } = useNumberFieldContext();
+  // The context ref drives caret control and scrubbing, so it must stay
+  // attached — merge the consumer's ref alongside it rather than letting
+  // either win. Memoized so React doesn't detach/reattach every render.
+  const mergedRef = useMemo(() => mergeRefs(ref, inputRef), [ref, inputRef]);
   // Merge a consumer aria-describedby (passed on <Input>) with the hook's
   // auto-wired value (the mounted <Description> id) instead of letting the
   // rest-spread clobber it — otherwise putting aria-describedby on the input
@@ -291,12 +295,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(function NumberFieldInput
     [rest["aria-describedby"], aria.inputProps["aria-describedby"]].filter(Boolean).join(" ") ||
     undefined;
   const el = (
-    <input
-      ref={inputRef as React.RefObject<HTMLInputElement>}
-      {...aria.inputProps}
-      {...rest}
-      aria-describedby={describedBy}
-    />
+    <input ref={mergedRef} {...aria.inputProps} {...rest} aria-describedby={describedBy} />
   );
   return renderWith(el, render, state);
 });
@@ -481,8 +480,9 @@ const Formatted = forwardRef<HTMLSpanElement, FormattedProps>(function NumberFie
  * recommended API; reach for {@link useNumberFieldState} + {@link useNumberField}
  * only when you need to own the DOM entirely.
  *
- * raqam ships **no styles**. Every part forwards `className`, `style` and refs,
- * so bring Tailwind, CSS Modules, or a design system.
+ * raqam ships **no styles** — bring Tailwind, CSS Modules, or a design system.
+ * Every part forwards `className`, `style` and refs, except `HiddenInput`,
+ * which takes no props at all.
  *
  * @example Quantity field
  * ```tsx
@@ -604,9 +604,14 @@ export const NumberField = {
    */
   Description,
   /**
-   * Validation message, linked via `aria-describedby` and rendered only while
-   * the field is invalid. With no children it prints the built-in range/validate
-   * message.
+   * Validation message, linked via `aria-describedby` and carrying
+   * `role="alert"`.
+   *
+   * With **no children** it renders the built-in range/validate message, and
+   * nothing while the field is valid. With **children** you own visibility —
+   * it renders them whenever they are truthy, so gate on
+   * `state.validationState === "invalid"` yourself or you will leave a
+   * permanent alert on screen.
    */
   ErrorMessage,
   /**

--- a/src/react/NumberField.tsx
+++ b/src/react/NumberField.tsx
@@ -476,17 +476,142 @@ const Formatted = forwardRef<HTMLSpanElement, FormattedProps>(function NumberFie
 
 // ── Namespace export ──────────────────────────────────────────────────────────
 
+/**
+ * Headless compound components for a live-formatting number input. This is the
+ * recommended API; reach for {@link useNumberFieldState} + {@link useNumberField}
+ * only when you need to own the DOM entirely.
+ *
+ * raqam ships **no styles**. Every part forwards `className`, `style` and refs,
+ * so bring Tailwind, CSS Modules, or a design system.
+ *
+ * @example Quantity field
+ * ```tsx
+ * import { NumberField } from "raqam";
+ *
+ * <NumberField.Root locale="en-US" defaultValue={1} minValue={0} maxValue={99}>
+ *   <NumberField.Label>Quantity</NumberField.Label>
+ *   <NumberField.Group>
+ *     <NumberField.Decrement>−</NumberField.Decrement>
+ *     <NumberField.Input />
+ *     <NumberField.Increment>+</NumberField.Increment>
+ *   </NumberField.Group>
+ * </NumberField.Root>
+ * ```
+ *
+ * @example Currency, submitted by a native form
+ * ```tsx
+ * <NumberField.Root
+ *   name="price"
+ *   locale="en-US"
+ *   formatOptions={{ style: "currency", currency: "USD" }}
+ *   defaultValue={1234.56}
+ *   minValue={0}
+ * >
+ *   <NumberField.Label>Price</NumberField.Label>
+ *   <NumberField.Group>
+ *     <NumberField.Input />
+ *   </NumberField.Group>
+ *   <NumberField.HiddenInput />
+ * </NumberField.Root>
+ * ```
+ *
+ * @example Persian digits — the locale plugin is a side-effect import
+ * ```tsx
+ * import { NumberField } from "raqam";
+ * import "raqam/locales/fa";
+ *
+ * <NumberField.Root locale="fa-IR" defaultValue={250000}>…</NumberField.Root>
+ * ```
+ *
+ * Rules that are easy to get wrong:
+ * - Configure everything on `Root`. `Input` takes no `value`/`onChange`/`type`.
+ * - Keep DOM order `Decrement, Input, Increment`; RTL flips them visually.
+ * - Native `<form>` submission needs `name` on `Root` **and** a `HiddenInput`,
+ *   because the visible input holds the formatted string.
+ * - Locale plugins (`raqam/locales/fa|ar|bn|hi|th`) are only needed to *type*
+ *   non-Latin digits; `locale` alone already formats them.
+ *
+ * @see https://raqam.47vigen.com/docs/api/components
+ */
 export const NumberField = {
+  /**
+   * Provider and outer `<div>`. Every other `NumberField.*` part must be nested
+   * inside it — they read state from context and throw otherwise.
+   *
+   * Formatting options live here, not on `Input`: `locale`, `formatOptions`
+   * (passed straight to `Intl.NumberFormat`), `minValue` / `maxValue`, `step`,
+   * `defaultValue` (uncontrolled) or `value` + `onValueChange` (controlled).
+   *
+   * Exposes `data-disabled`, `data-invalid`, `data-focused` and `data-scrubbing`
+   * for styling.
+   */
   Root,
+  /**
+   * `<label>` wired to the input via `htmlFor` automatically — do not set your
+   * own `htmlFor` or `id`. Omitting it leaves the field unlabelled; pass
+   * `aria-label` on `Input` instead if the design has no visible label.
+   */
   Label,
+  /**
+   * Optional `<div>` wrapping `Input` with the stepper buttons, carrying
+   * `role="group"` and the field's `aria-labelledby`. Style the visual border
+   * here — the input itself is unstyled and borderless by design.
+   */
   Group,
+  /**
+   * The editable `<input role="spinbutton">`. Formats live as the user types
+   * while keeping the caret in place, and accepts non-Latin digits when the
+   * matching locale plugin is imported.
+   *
+   * `type` is fixed (`text` with `inputMode="decimal"`) — `type="number"` would
+   * defeat formatting. Configure behaviour on `Root`, not here; `value`,
+   * `onChange` and the keyboard model are supplied for you.
+   */
   Input,
+  /**
+   * Stepper button that adds `step`. Press-and-hold repeats. Auto-disables at
+   * `maxValue`. Supply the visible glyph as children (e.g. `+`); the accessible
+   * name and `type="button"` are set for you.
+   */
   Increment,
+  /**
+   * Stepper button that subtracts `step`. Press-and-hold repeats. Auto-disables
+   * at `minValue`. In RTL locales it renders on the visual right automatically —
+   * keep the DOM order Decrement, Input, Increment.
+   */
   Decrement,
+  /**
+   * Hidden `<input>` carrying the raw number for native form submission — the
+   * visible input holds the *formatted* string, so a plain `<form>` POST would
+   * otherwise send `"$1,234.56"`. Requires `name` on `Root`. Renders nothing
+   * without it. Not needed with react-hook-form, Formik, or any controlled setup.
+   */
   HiddenInput,
+  /**
+   * Drag-to-change surface (the Figma-style scrub handle). Pointer-locks on
+   * drag and steps the value by `pixelSensitivity` pixels per `step`. Wrap the
+   * label or an icon in it. Pair with `ScrubAreaCursor` for a custom cursor.
+   */
   ScrubArea,
+  /**
+   * Custom cursor rendered at the virtual pointer position while scrubbing, and
+   * nothing otherwise. Must be nested inside `ScrubArea`.
+   */
   ScrubAreaCursor,
+  /**
+   * Help text, linked to the input through `aria-describedby`. Use it instead of
+   * a bare `<p>` so screen readers announce it with the field.
+   */
   Description,
+  /**
+   * Validation message, linked via `aria-describedby` and rendered only while
+   * the field is invalid. With no children it prints the built-in range/validate
+   * message.
+   */
   ErrorMessage,
+  /**
+   * Read-only `<span>` mirroring the formatted display value, `aria-hidden` so
+   * it is not announced twice. Handy for previews and RTL-safe inline text.
+   */
   Formatted,
 };

--- a/src/react/useNumberField.ts
+++ b/src/react/useNumberField.ts
@@ -92,6 +92,19 @@ function parseSpecialNotation(s: string): number | null {
   return null;
 }
 
+/**
+ * Turns {@link useNumberFieldState} into ready-to-spread prop objects:
+ * `inputProps` (WAI-ARIA `spinbutton` role, `aria-valuenow`/`min`/`max`/`text`,
+ * the full keyboard model), `labelProps`, `incrementButtonProps`,
+ * `decrementButtonProps`, `groupProps`, `descriptionProps`, `errorMessageProps`
+ * and `hiddenInputProps`.
+ *
+ * The other half of the Hook API — pass the **same** options object you gave
+ * `useNumberFieldState`, plus a `label`, and an `inputRef` attached to the real
+ * `<input>` (caret control and scrubbing need the node).
+ *
+ * @see https://raqam.47vigen.com/docs/api/use-number-field
+ */
 export function useNumberField(
   props: UseNumberFieldProps,
   state: NumberFieldState,

--- a/src/react/useNumberFieldState.ts
+++ b/src/react/useNumberFieldState.ts
@@ -51,6 +51,32 @@ function decimalPlaces(n: number): number {
 
 // ── Hook ──────────────────────────────────────────────────────────────────────
 
+/**
+ * State machine for a number field: the formatted display string, the parsed
+ * numeric value, validation, focus, and scrubbing. Half of the Hook API —
+ * pair it with {@link useNumberField}, which turns this state into ARIA props
+ * and event handlers.
+ *
+ * Prefer `NumberField.*` unless you need to own the DOM. Both hooks must
+ * receive the **same** options object, since each builds its own formatter.
+ *
+ * @example
+ * ```tsx
+ * const options = {
+ *   locale: "en-US",
+ *   formatOptions: { style: "currency", currency: "USD" },
+ *   minValue: 0,
+ *   defaultValue: 1234.56,
+ * } satisfies UseNumberFieldStateOptions;
+ *
+ * const state = useNumberFieldState(options);
+ * const inputRef = useRef<HTMLInputElement>(null);
+ * const { inputProps, labelProps, incrementButtonProps, decrementButtonProps } =
+ *   useNumberField({ ...options, label: "Price" }, state, inputRef);
+ * ```
+ *
+ * @see https://raqam.47vigen.com/docs/api/use-number-field-state
+ */
 export function useNumberFieldState(options: UseNumberFieldStateOptions): NumberFieldState {
   const {
     locale,


### PR DESCRIPTION
Someone tells their agent *"build me a number field with raqam"*. Four surfaces decide whether that works first try — and each had a gap.

## 1. The shipped types said almost nothing

This is the surface that matters most: it's what an agent reads in the consumer's `node_modules`, offline, with no docs fetch. `dist/react.d.ts` carried **3** JSDoc blocks for the entire React API. An agent looking up `NumberField.Group` found:

```ts
interface GroupProps extends React__default.HTMLAttributes<HTMLDivElement> {}
```

Now **18** blocks, covering `NumberField` and all twelve parts plus `useNumberFieldState` and `useNumberField` — composition rules, runnable examples, and the things that bite:

- configure formatting on `Root`, never `Input`
- `Input`'s `type` is fixed — `type="number"` defeats formatting
- keep DOM order `Decrement, Input, Increment`; RTL flips them visually
- native `<form>` submission needs `name` on `Root` **and** `HiddenInput`, because the visible input holds the formatted string

**Implementation note worth keeping:** the docs sit on the properties of the exported `NumberField` object literal, not on the internal `const Root = forwardRef(...)`. Declaration emit synthesizes the namespace object type and silently drops const-level docs — I put them on the consts first and only 6 of 12 survived the build. `AGENTS.md` now records this.

Types only. No runtime change: 688 tests pass, size-limit unmoved (core 2.23 kB).

## 2. No `llms.txt`

Added `/llms.txt` — an [llmstxt.org](https://llmstxt.org) index with a preamble of the rules above, then every page grouped by section with a raw-markdown URL each. And `/llms-full.txt`, the whole corpus in one request (136 KB).

## 3. `/api/md/*` was serving title-only pages

Found while wiring `llms-full.txt`. The route read `page.data._markdown`, which is `undefined` in fumadocs-mdx 15 — the API is `await page.data.getText("processed")`. It failed silently, so the **"Copy Markdown"** and **"Open in…"** page actions had been handing over ~100 bytes:

```
$ curl .../api/md/api/components | wc -c
100     # before — title + description, no body
12421   # after
```

## 4. The skill made an agent read 154 lines and fetch the web first

`skills/raqam/SKILL.md` was thorough but front-loaded links, and explicitly told the agent to prefer fetching docs over local knowledge. It now opens with a **complete working answer** — install command, full component, a variation table (currency / percent / Persian / native form / controlled), and the four mistakes — so an agent can act before any network call. Its escalation path now starts with reading the installed `.d.ts` and only then goes to the network.

README gains a short section pointing at all of this. `AGENTS.md` is new, for agents working *in* the repo — layout, what "green" means, and the two rules that are easy to undo by accident (TypeScript stays on 5.x; JSDoc placement).

## Verified

| check | result |
|---|---|
| `pnpm typecheck` / `test` / `lint` | pass · 688 tests |
| `pnpm build` + `publint` | pass · "All good!" |
| `pnpm size` | core 2.23 kB, full 9.61 kB — unchanged |
| shipped JSDoc blocks in `dist/react.d.ts` | 3 → 18 |
| `/api/md/api/components` | 100 B → 12.4 KB |
| `/llms.txt`, `/llms-full.txt` | 200, correct sections, 136 KB |
| docs `typecheck` + `next build` | pass · 51 static pages |

🤖 Generated with [Claude Code](https://claude.com/claude-code)