### PR TITLE
fix(docs): give the playground bundler time to cold-build a new release

### DIFF
--- a/docs/components/playground/RaqamSandpack.tsx
+++ b/docs/components/playground/RaqamSandpack.tsx
@@ -65,7 +65,10 @@ export function RaqamSandpack() {
             "/App.tsx": PLAYGROUND_APP_BY_ID[templateId],
             "/styles.css": { code: playgroundStyles(sandpackTheme), hidden: true },
           }}
-          options={{ initMode: "user-visible" }}
+          // The default ~40s bundler timeout can't cold-build a freshly
+          // published version — every attempt dies mid-download, so the cache
+          // never warms and the playground stays broken after each release.
+          options={{ initMode: "user-visible", bundlerTimeOut: 180_000 }}
         >
           {/* SandpackLayout is a bare container — an empty one renders nothing. */}
           <SandpackLayout>


### PR DESCRIPTION
Found while verifying the `raqam@0.4.3` release: the playground broke the moment the version bumped.

Sandpack's default bundler timeout (~40s) is shorter than a **cold build of a freshly published version**. Every attempt died mid-download with `Couldn't connect to server / ERROR: TIME_OUT` — and because it never finished, the CodeSandbox cache never warmed, so the failure repeated instead of self-healing.

## It's build time, not package content

| pinned version | result |
|---|---|
| `0.4.2` (cached at CodeSandbox for months) | bundles fine — 2/2 runs, locally |
| `0.4.3` (published minutes earlier) | `TIME_OUT` — 5/5 runs, local **and** production |
| `latest` (resolves to 0.4.3) | `TIME_OUT` |

Ruled out on the package side:

- `npm install raqam` gives a working 0.4.3 — all six entry points resolve from ESM and CJS, both fixes present, 18 JSDoc blocks in `dist/react.d.ts`
- Sandpack's own packager manifest for 0.4.3 is complete: 14 entries, same shape as 0.4.2, **zero unresolved relative requires** (checked by walking every `require()` in the manifest)
- the two versions' shipped CJS is byte-identical per entry point; `package.json` differs by 2 bytes — the version string
- jsDelivr serves both versions; unpkg is unreachable for both, so not a differentiator

With the timeout raised the run no longer errors at 40s and keeps downloading — the remaining slowness is CodeSandbox's packager backend, which is outside this repo.

180s lets the first visitor after a release finish the build, which warms the cache for everyone after them.

**This is a release-time trap, not a one-off:** the sandbox pins `raqam@{pkg.version}`, so every future publish hits a cold cache. Worth knowing when watching the playground right after a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)