### PR TITLE
perf(docs): stop the playground downloading create-react-app to render one input

### DIFF
--- a/docs/components/playground/RaqamSandpack.tsx
+++ b/docs/components/playground/RaqamSandpack.tsx
@@ -16,6 +16,48 @@ import {
   type PlaygroundTemplateId,
 } from "./playground-templates"
 
+/**
+ * Hand-rolled instead of `template="react-ts"`.
+ *
+ * That template declares `react-scripts@4` and `typescript@4`, and Sandpack
+ * merges template dependencies with ours rather than replacing them — so the
+ * sandbox was resolving 20.4 MB of packager payload to render one input.
+ * TypeScript alone is 10.9 MB and react-scripts 2.0 MB, neither of which the
+ * demo runs: the create-react-app environment transpiles TSX itself. Dropping
+ * both leaves react + react-dom + raqam, about 7.5 MB.
+ *
+ * `tsconfig.json` has to stay — without `jsx: react-jsx` the entry never
+ * transpiles and the preview renders blank.
+ */
+const ENTRY = `import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);
+`
+
+const TSCONFIG = `{
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["dom", "es2015"],
+    "jsx": "react-jsx"
+  }
+}
+`
+
+const INDEX_HTML = `<!DOCTYPE html>
+<html lang="en">
+  <head><meta charset="UTF-8" /></head>
+  <body><div id="root"></div></body>
+</html>
+`
+
 export function RaqamSandpack() {
   const [templateId, setTemplateId] = useState<PlaygroundTemplateId>("starter")
   const [mounted, setMounted] = useState(false)
@@ -58,17 +100,32 @@ export function RaqamSandpack() {
           // Remount on switch: Fast Refresh keeps the old state, so a new
           // template's defaultValue would otherwise never take effect.
           key={templateId}
-          template="react-ts"
           theme={sandpackTheme}
-          customSetup={{ dependencies: { raqam: RAQAM_VERSION } }}
+          customSetup={{
+            environment: "create-react-app",
+            entry: "/index.tsx",
+            dependencies: {
+              react: "^19.0.0",
+              "react-dom": "^19.0.0",
+              raqam: RAQAM_VERSION,
+            },
+          }}
           files={{
             "/App.tsx": PLAYGROUND_APP_BY_ID[templateId],
             "/styles.css": { code: playgroundStyles(sandpackTheme), hidden: true },
+            "/index.tsx": { code: ENTRY, hidden: true },
+            "/tsconfig.json": { code: TSCONFIG, hidden: true },
+            "/public/index.html": { code: INDEX_HTML, hidden: true },
           }}
           // The default ~40s bundler timeout can't cold-build a freshly
           // published version — every attempt dies mid-download, so the cache
           // never warms and the playground stays broken after each release.
-          options={{ initMode: "user-visible", bundlerTimeOut: 180_000 }}
+          options={{
+            initMode: "user-visible",
+            bundlerTimeOut: 180_000,
+            activeFile: "/App.tsx",
+            visibleFiles: ["/App.tsx"],
+          }}
         >
           {/* SandpackLayout is a bare container — an empty one renders nothing. */}
           <SandpackLayout>


### PR DESCRIPTION
## Why it was slow

`template="react-ts"` looked innocent. But Sandpack **merges** template dependencies with `customSetup.dependencies` rather than replacing them:

```js
dependencies: { ...baseTemplate.dependencies, ...customSetup?.dependencies }
```

So the sandbox's real dependency set was react + react-dom + raqam **plus** the template's `react-scripts@4` and `typescript@4`.

Measured against the CodeSandbox packager (`prod-packager-packages.codesandbox.io`), that set is **20.4 MB**:

| package | packager payload | share |
|---|---:|---:|
| `typescript@4.9.5` | 10.9 MB | 53% |
| `react-dom@19.2.0` | 7.4 MB | 36% |
| `react-scripts@4.0.3` | 2.0 MB | 10% |
| `react@19.2.0` | 96 KB | — |
| **`raqam@0.4.3`** | **45 KB** | **0.2%** |

Neither TypeScript nor react-scripts actually runs — the `create-react-app` environment transpiles TSX with its own pipeline. They were **63% of the download** for a demo whose subject is 45 KB.

## The change

Dropped the template and hand-rolled the minimum: entry, `tsconfig.json` and `index.html` inline, dependencies limited to react, react-dom and raqam. ~20.4 MB → ~7.5 MB.

`tsconfig.json` has to stay — without `jsx: "react-jsx"` the entry never transpiles and the preview renders blank with no error. That one cost me a confused half hour, so it's commented in the file.

## Verified

Cold sandbox, all three examples, both themes:

- **Starter** — renders `− 1 +`
- **Persian** — renders `ریال ۲۵۰٬۰۰۰`, RTL, steppers flipped correctly
- **Currency** — renders, `name` on Root so `HiddenInput` actually mounts

The equivalent `create-react-app` run did not finish inside the same observation window on the same machine and network.

Docs `typecheck` and `next build` (51 static pages) both pass.

## What this does not fix

CodeSandbox's packager is still slow to cold-build a version it has never seen, so the first load right after a release will still take a while. This cuts what we ask it for by nearly two thirds; it doesn't make their backend faster. The 180s `bundlerTimeOut` from #76 stays for exactly that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)